### PR TITLE
many, many thing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ add_executable(pcomm
     src/base32.c
     src/identity.c
     src/crypto.c
+    src/bencode.c
+    src/dht.c
+    src/cell.c
+    src/circuit.c
     src/db.c
     src/net.c
     src/proto.c

--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@ PComm is a **prototype** onion-relay messenger written in **pure C** with:
 - A minimal embedded **HTTP server** serving a barebone **HTML/CSS/JS UI**
 - **User identifiers** derived from an X25519 public key (self-certifying ID)
 - **E2E encryption** using X25519 + HKDF-SHA256 + ChaCha20-Poly1305
-- **Onion-style forwarding** (up to 3 hops) with optional **single-roundtrip** forwarding for mailbox polling
-- A Tor-inspired **intro/HSDir mailbox model**:
-  - users publish a small **descriptor** (intro points) to HSDirs
-  - senders deliver encrypted messages to a recipient mailbox **by ID only** (no recipient IP required)
-  - recipients poll mailboxes via onion-routed requests
+- **Long-lived circuits** (3 hops) with **stream multiplexing** (Tor-like RELAY BEGIN/DATA/END)
+- A Tor-inspired **intro + mailbox** model for messaging **by ID only** (no recipient IP required)
+  - users publish a small **descriptor** (intro points) onto a few storage relays
+  - storage relays announce themselves in a **BEP-5 DHT** under the user’s descriptor/mailbox infohash
+  - senders discover descriptor/mailbox hosts via DHT (`get_peers`) and deliver encrypted messages there
+  - recipients poll mailboxes via circuit-routed requests and store messages locally
 - A simple **mesh gossip** mechanism (HELLO + peer exchange) so new nodes can quickly learn relays
 - Lightweight **cover traffic** (NOOP onions) to make traffic less bursty
 
-> ⚠️ This is not production-ready anonymity software. It is missing many protections a real Tor implementation relies on (robust directory, guard policies, padding schedules, congestion control, DoS hardening, long-lived circuits, time-correlation defenses, etc.). Use for learning/testing only.
+> ⚠️ This is not production-ready anonymity software. It is missing many protections a real Tor implementation relies on (guards policy, robust padding, congestion control, DoS hardening, timing-correlation defenses, etc.). Use for learning/testing only.
 
 ## Build
 
@@ -74,7 +75,7 @@ PComm will:
 You can send to a user **just by their ID**:
 - add them to contacts (host/port optional), or just paste their ID into the send box
 - the sender encrypts E2E to the recipient public key (derived from the ID)
-- the encrypted blob is delivered to the recipient mailbox stored on HSDirs + (if available) intro points
+- the encrypted blob is delivered to the recipient mailbox stored on relays discovered via the BEP-5 DHT (with HSDir-style fallback)
 
 The recipient periodically polls those mailboxes and stores messages locally.
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 # PComm (prototype)
 
-PComm is a **prototype** onion-relay messenger written in **pure C** with:
-- **SQLite** storage for chats (schema supports direct + group conversations)
-- A minimal embedded **HTTP server** serving a barebone **HTML/CSS/JS UI**
-- **User identifiers** derived from an X25519 public key (self-certifying ID)
-- **E2E encryption** using X25519 + HKDF-SHA256 + ChaCha20-Poly1305
-- **Long-lived circuits** (3 hops) with **stream multiplexing** (Tor-like RELAY BEGIN/DATA/END)
-- A Tor-inspired **intro + mailbox** model for messaging **by ID only** (no recipient IP required)
-  - users publish a small **descriptor** (intro points) onto a few storage relays
-  - storage relays announce themselves in a **BEP-5 DHT** under the user’s descriptor/mailbox infohash
-  - senders discover descriptor/mailbox hosts via DHT (`get_peers`) and deliver encrypted messages there
-  - recipients poll mailboxes via circuit-routed requests and store messages locally
-- A simple **mesh gossip** mechanism (HELLO + peer exchange) so new nodes can quickly learn relays
-- Lightweight **cover traffic** (NOOP onions) to make traffic less bursty
+# PComm (prototype)
 
-> ⚠️ This is not production-ready anonymity software. It is missing many protections a real Tor implementation relies on (guards policy, robust padding, congestion control, DoS hardening, timing-correlation defenses, etc.). Use for learning/testing only.
+PComm is a **prototype** as of rn, an onion-relay messenger written in pure C (the graph lies shhhhhh) with:
+- SQLite message storage (schema designed to extend to group chats later if I'm not too lazy)
+- A dogshit embedded HTTP server that serves a barebone HTML/CSS/JS UI
+- User identifiers derived from a Curve25519 (X25519) public key
+- E2E encryption using X25519 + HKDF-SHA256 + ChaCha20-Poly1305
+- Onion-style forwarding type shit through relay peers (3 max in this prototype for now)
+- A Tor-ripped-off intro/HSDir mailbox model:
+  - users publish a small descriptor (intro points) to HSDirs
+  - senders deliver encrypted messages to a recipient mailbox (no recipient IP required)
+  - recipients poll mailboxes via onion-routed requests
+- A simple mesh gossip mechanism (HELLO + peer exchange) so new nodes can quickly learn relays
+- Lightweight cover traffic (NOOP onions) to make traffic less bursty
 
 It is inspired from my good friend [S3](https://github.com/S3NP41-v) [Pcomm project](https://github.com/S3NP41-v/PComm)
 

--- a/src/base32.h
+++ b/src/base32.h
@@ -4,7 +4,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+// RFC4648 Base32 without padding.
+// Returns number of chars written (excluding NUL) or -1 on error.
 int base32_encode_no_pad(const uint8_t *in, size_t in_len, char *out, size_t out_cap);
+
+// Decodes RFC4648 Base32 (accepts upper/lowercase, ignores '='). Returns bytes written or -1.
 int base32_decode_no_pad(const char *in, uint8_t *out, size_t out_cap);
 
 #endif

--- a/src/bencode.c
+++ b/src/bencode.c
@@ -1,0 +1,302 @@
+#include "bencode.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <ctype.h>
+
+static benc_t *alloc_node(benc_type_t t) {
+    benc_t *n = (benc_t*)calloc(1, sizeof(benc_t));
+    if (!n) return NULL;
+    n->t = t;
+    return n;
+}
+
+benc_t *benc_new_int(int64_t v) {
+    benc_t *n = alloc_node(BENC_INT);
+    if (!n) return NULL;
+    n->i = v;
+    return n;
+}
+
+benc_t *benc_new_str(const uint8_t *s, size_t slen) {
+    benc_t *n = alloc_node(BENC_STR);
+    if (!n) return NULL;
+    if (slen) {
+        n->s = (uint8_t*)malloc(slen);
+        if (!n->s) { free(n); return NULL; }
+        memcpy(n->s, s, slen);
+    }
+    n->slen = slen;
+    return n;
+}
+
+benc_t *benc_new_list(void) {
+    return alloc_node(BENC_LIST);
+}
+
+benc_t *benc_new_dict(void) {
+    return alloc_node(BENC_DICT);
+}
+
+int benc_list_add(benc_t *l, benc_t *item) {
+    if (!l || l->t != BENC_LIST || !item) return -1;
+    benc_t **nl = (benc_t**)realloc(l->list, (l->list_len + 1) * sizeof(benc_t*));
+    if (!nl) return -1;
+    l->list = nl;
+    l->list[l->list_len++] = item;
+    return 0;
+}
+
+int benc_dict_set(benc_t *d, const char *key, benc_t *val) {
+    if (!d || d->t != BENC_DICT || !key || !val) return -1;
+    size_t klen = strlen(key);
+    // replace if exists
+    for (size_t i=0;i<d->dict_len;i++) {
+        if (d->dict[i].klen == klen && memcmp(d->dict[i].k, key, klen) == 0) {
+            benc_free(d->dict[i].v);
+            d->dict[i].v = val;
+            return 0;
+        }
+    }
+    benc_kv_t *nd = (benc_kv_t*)realloc(d->dict, (d->dict_len + 1) * sizeof(benc_kv_t));
+    if (!nd) return -1;
+    d->dict = nd;
+    char *kcopy = (char*)malloc(klen);
+    if (!kcopy) return -1;
+    memcpy(kcopy, key, klen);
+    d->dict[d->dict_len].k = kcopy;
+    d->dict[d->dict_len].klen = klen;
+    d->dict[d->dict_len].v = val;
+    d->dict_len++;
+    return 0;
+}
+
+void benc_free(benc_t *n) {
+    if (!n) return;
+    if (n->t == BENC_STR) {
+        free(n->s);
+    } else if (n->t == BENC_LIST) {
+        for (size_t i=0;i<n->list_len;i++) benc_free(n->list[i]);
+        free(n->list);
+    } else if (n->t == BENC_DICT) {
+        for (size_t i=0;i<n->dict_len;i++) {
+            free((void*)n->dict[i].k);
+            benc_free(n->dict[i].v);
+        }
+        free(n->dict);
+    }
+    free(n);
+}
+
+benc_t *benc_dict_get(benc_t *d, const char *key) {
+    if (!d || d->t != BENC_DICT || !key) return NULL;
+    size_t klen = strlen(key);
+    for (size_t i=0;i<d->dict_len;i++) {
+        if (d->dict[i].klen == klen && memcmp(d->dict[i].k, key, klen) == 0) return d->dict[i].v;
+    }
+    return NULL;
+}
+
+static int parse_int(const uint8_t *buf, size_t len, size_t *pos, benc_t **out) {
+    // i<digits>e
+    if (*pos >= len || buf[*pos] != 'i') return -1;
+    (*pos)++;
+    if (*pos >= len) return -1;
+    int neg = 0;
+    if (buf[*pos] == '-') { neg = 1; (*pos)++; }
+    if (*pos >= len || !isdigit(buf[*pos])) return -1;
+    int64_t v = 0;
+    while (*pos < len && isdigit(buf[*pos])) {
+        v = v * 10 + (buf[*pos] - '0');
+        (*pos)++;
+    }
+    if (*pos >= len || buf[*pos] != 'e') return -1;
+    (*pos)++;
+    if (neg) v = -v;
+    *out = benc_new_int(v);
+    return *out ? 0 : -1;
+}
+
+static int parse_str(const uint8_t *buf, size_t len, size_t *pos, benc_t **out) {
+    // <len>:<bytes>
+    if (*pos >= len || !isdigit(buf[*pos])) return -1;
+    size_t n = 0;
+    while (*pos < len && isdigit(buf[*pos])) {
+        n = n*10 + (size_t)(buf[*pos]-'0');
+        (*pos)++;
+        if (n > 1024*1024) return -1;
+    }
+    if (*pos >= len || buf[*pos] != ':') return -1;
+    (*pos)++;
+    if (*pos + n > len) return -1;
+    *out = benc_new_str(buf + *pos, n);
+    if (!*out) return -1;
+    *pos += n;
+    return 0;
+}
+
+static int parse_list(const uint8_t *buf, size_t len, size_t *pos, benc_t **out);
+static int parse_dict(const uint8_t *buf, size_t len, size_t *pos, benc_t **out);
+
+static int parse_any(const uint8_t *buf, size_t len, size_t *pos, benc_t **out) {
+    if (*pos >= len) return -1;
+    uint8_t c = buf[*pos];
+    if (c == 'i') return parse_int(buf, len, pos, out);
+    if (c == 'l') return parse_list(buf, len, pos, out);
+    if (c == 'd') return parse_dict(buf, len, pos, out);
+    if (isdigit(c)) return parse_str(buf, len, pos, out);
+    return -1;
+}
+
+static int parse_list(const uint8_t *buf, size_t len, size_t *pos, benc_t **out) {
+    if (*pos >= len || buf[*pos] != 'l') return -1;
+    (*pos)++;
+    benc_t *l = benc_new_list();
+    if (!l) return -1;
+    while (*pos < len && buf[*pos] != 'e') {
+        benc_t *item = NULL;
+        if (parse_any(buf, len, pos, &item) != 0) { benc_free(l); return -1; }
+        if (benc_list_add(l, item) != 0) { benc_free(item); benc_free(l); return -1; }
+    }
+    if (*pos >= len || buf[*pos] != 'e') { benc_free(l); return -1; }
+    (*pos)++;
+    *out = l;
+    return 0;
+}
+
+static int parse_dict(const uint8_t *buf, size_t len, size_t *pos, benc_t **out) {
+    if (*pos >= len || buf[*pos] != 'd') return -1;
+    (*pos)++;
+    benc_t *d = benc_new_dict();
+    if (!d) return -1;
+    while (*pos < len && buf[*pos] != 'e') {
+        benc_t *k = NULL;
+        if (parse_str(buf, len, pos, &k) != 0) { benc_free(d); return -1; }
+        benc_t *v = NULL;
+        if (parse_any(buf, len, pos, &v) != 0) { benc_free(k); benc_free(d); return -1; }
+        // key bytes are not NUL-terminated; copy into C string
+        char *ks = (char*)malloc(k->slen + 1);
+        if (!ks) { benc_free(k); benc_free(v); benc_free(d); return -1; }
+        memcpy(ks, k->s, k->slen);
+        ks[k->slen] = '\0';
+        benc_free(k);
+        if (benc_dict_set(d, ks, v) != 0) { free(ks); benc_free(v); benc_free(d); return -1; }
+        free(ks);
+    }
+    if (*pos >= len || buf[*pos] != 'e') { benc_free(d); return -1; }
+    (*pos)++;
+    *out = d;
+    return 0;
+}
+
+int benc_parse(const uint8_t *buf, size_t len, benc_t **out, size_t *used) {
+    if (!buf || !out) return -1;
+    *out = NULL;
+    size_t pos = 0;
+    benc_t *n = NULL;
+    if (parse_any(buf, len, &pos, &n) != 0) return -1;
+    if (used) *used = pos;
+    *out = n;
+    return 0;
+}
+
+// --- encoding ---
+
+typedef struct {
+    uint8_t *b;
+    size_t len;
+    size_t cap;
+} wbuf_t;
+
+static int wb_grow(wbuf_t *w, size_t add) {
+    if (w->len + add <= w->cap) return 0;
+    size_t nc = w->cap ? w->cap*2 : 256;
+    while (nc < w->len + add) nc *= 2;
+    uint8_t *nb = (uint8_t*)realloc(w->b, nc);
+    if (!nb) return -1;
+    w->b = nb;
+    w->cap = nc;
+    return 0;
+}
+
+static int wb_put(wbuf_t *w, const void *p, size_t n) {
+    if (wb_grow(w, n) != 0) return -1;
+    memcpy(w->b + w->len, p, n);
+    w->len += n;
+    return 0;
+}
+
+static int enc_any(wbuf_t *w, const benc_t *n);
+
+static int enc_int(wbuf_t *w, int64_t v) {
+    char tmp[64];
+    int m = snprintf(tmp, sizeof(tmp), "i%llde", (long long)v);
+    if (m <= 0) return -1;
+    return wb_put(w, tmp, (size_t)m);
+}
+
+static int enc_str(wbuf_t *w, const uint8_t *s, size_t slen) {
+    char tmp[64];
+    int m = snprintf(tmp, sizeof(tmp), "%zu:", slen);
+    if (m <= 0) return -1;
+    if (wb_put(w, tmp, (size_t)m) != 0) return -1;
+    if (slen) return wb_put(w, s, slen);
+    return 0;
+}
+
+static int enc_list(wbuf_t *w, const benc_t *n) {
+    if (wb_put(w, "l", 1) != 0) return -1;
+    for (size_t i=0;i<n->list_len;i++) if (enc_any(w, n->list[i]) != 0) return -1;
+    return wb_put(w, "e", 1);
+}
+
+static int kv_cmp(const void *a, const void *b) {
+    const benc_kv_t *ka = (const benc_kv_t*)a;
+    const benc_kv_t *kb = (const benc_kv_t*)b;
+    size_t ml = ka->klen < kb->klen ? ka->klen : kb->klen;
+    int c = memcmp(ka->k, kb->k, ml);
+    if (c != 0) return c;
+    if (ka->klen < kb->klen) return -1;
+    if (ka->klen > kb->klen) return 1;
+    return 0;
+}
+
+static int enc_dict(wbuf_t *w, const benc_t *n) {
+    if (wb_put(w, "d", 1) != 0) return -1;
+    // spec requires lexicographic order; sort a copy
+    benc_kv_t *tmp = NULL;
+    if (n->dict_len) {
+        tmp = (benc_kv_t*)malloc(n->dict_len * sizeof(benc_kv_t));
+        if (!tmp) return -1;
+        memcpy(tmp, n->dict, n->dict_len * sizeof(benc_kv_t));
+        qsort(tmp, n->dict_len, sizeof(benc_kv_t), kv_cmp);
+    }
+    for (size_t i=0;i<n->dict_len;i++) {
+        if (enc_str(w, (const uint8_t*)tmp[i].k, tmp[i].klen) != 0) { free(tmp); return -1; }
+        if (enc_any(w, tmp[i].v) != 0) { free(tmp); return -1; }
+    }
+    free(tmp);
+    return wb_put(w, "e", 1);
+}
+
+static int enc_any(wbuf_t *w, const benc_t *n) {
+    if (!n) return -1;
+    switch (n->t) {
+        case BENC_INT: return enc_int(w, n->i);
+        case BENC_STR: return enc_str(w, n->s, n->slen);
+        case BENC_LIST: return enc_list(w, n);
+        case BENC_DICT: return enc_dict(w, n);
+        default: return -1;
+    }
+}
+
+int benc_encode(const benc_t *n, uint8_t **out, size_t *out_len) {
+    if (!n || !out || !out_len) return -1;
+    *out = NULL; *out_len = 0;
+    wbuf_t w = {0};
+    if (enc_any(&w, n) != 0) { free(w.b); return -1; }
+    *out = w.b;
+    *out_len = w.len;
+    return 0;
+}

--- a/src/bencode.h
+++ b/src/bencode.h
@@ -1,0 +1,51 @@
+#ifndef PCOMM_BENCODE_H
+#define PCOMM_BENCODE_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+typedef enum {
+    BENC_INT,
+    BENC_STR,
+    BENC_LIST,
+    BENC_DICT,
+} benc_type_t;
+
+typedef struct benc benc_t;
+
+typedef struct {
+    const char *k;
+    size_t klen;
+    benc_t *v;
+} benc_kv_t;
+
+struct benc {
+    benc_type_t t;
+    int64_t i;
+    uint8_t *s;
+    size_t slen;
+    benc_t **list;
+    size_t list_len;
+    benc_kv_t *dict;
+    size_t dict_len;
+};
+
+// Parse bencode. Returns 0 on success.
+int benc_parse(const uint8_t *buf, size_t len, benc_t **out, size_t *used);
+void benc_free(benc_t *n);
+
+// Dict helpers
+benc_t *benc_dict_get(benc_t *d, const char *key);
+
+// Encode bencode. Allocates *out; caller frees.
+int benc_encode(const benc_t *n, uint8_t **out, size_t *out_len);
+
+// Convenience constructors (allocated nodes)
+benc_t *benc_new_int(int64_t v);
+benc_t *benc_new_str(const uint8_t *s, size_t slen);
+benc_t *benc_new_list(void);
+benc_t *benc_new_dict(void);
+int benc_list_add(benc_t *l, benc_t *item);
+int benc_dict_set(benc_t *d, const char *key, benc_t *val);
+
+#endif

--- a/src/cell.c
+++ b/src/cell.c
@@ -1,0 +1,203 @@
+#include "cell.h"
+#include "crypto.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <arpa/inet.h>
+
+static void put_u16(uint8_t *p, uint16_t v){ uint16_t n=htons(v); memcpy(p,&n,2); }
+static void put_u32(uint8_t *p, uint32_t v){ uint32_t n=htonl(v); memcpy(p,&n,4); }
+static uint16_t get_u16(const uint8_t *p){ uint16_t n; memcpy(&n,p,2); return ntohs(n); }
+static uint32_t get_u32(const uint8_t *p){ uint32_t n; memcpy(&n,p,4); return ntohl(n); }
+
+int pcomm_cell_pack(uint32_t circ_id, uint8_t cmd, uint8_t flags, const uint8_t *payload, uint16_t payload_len,
+                    uint8_t **out, uint32_t *out_len) {
+    if (!out || !out_len) return -1;
+    *out = NULL; *out_len = 0;
+    if (payload_len > PCOMM_CELL_MAX_PAYLOAD) return -1;
+
+    uint32_t total = PCOMM_CELL_HDR_LEN + payload_len;
+    uint8_t *buf = (uint8_t*)malloc(total);
+    if (!buf) return -1;
+
+    put_u32(buf, circ_id);
+    buf[4] = cmd;
+    buf[5] = flags;
+    put_u16(buf + 6, payload_len);
+    if (payload_len && payload) memcpy(buf + PCOMM_CELL_HDR_LEN, payload, payload_len);
+
+    *out = buf;
+    *out_len = total;
+    return 0;
+}
+
+int pcomm_cell_unpack(const uint8_t *buf, uint32_t buf_len, uint32_t *circ_id, uint8_t *cmd, uint8_t *flags,
+                      const uint8_t **payload, uint16_t *payload_len) {
+    if (!buf || buf_len < PCOMM_CELL_HDR_LEN || !circ_id || !cmd || !flags || !payload || !payload_len) return -1;
+
+    *circ_id = get_u32(buf);
+    *cmd = buf[4];
+    *flags = buf[5];
+    uint16_t pl = get_u16(buf + 6);
+    if (PCOMM_CELL_HDR_LEN + pl != buf_len) return -1;
+    *payload_len = pl;
+    *payload = buf + PCOMM_CELL_HDR_LEN;
+    return 0;
+}
+
+int pcomm_relay_plain_pack(uint8_t relay_cmd, uint16_t stream_id, const uint8_t *body, uint16_t body_len,
+                           uint8_t **out, uint16_t *out_len) {
+    if (!out || !out_len) return -1;
+    *out = NULL; *out_len = 0;
+    uint32_t total = PCOMM_RELAY_HDR_LEN + body_len;
+    uint8_t *buf = (uint8_t*)malloc(total);
+    if (!buf) return -1;
+    buf[0] = relay_cmd;
+    put_u16(buf + 1, stream_id);
+    buf[3] = 0;
+    put_u16(buf + 4, body_len);
+    if (body_len && body) memcpy(buf + PCOMM_RELAY_HDR_LEN, body, body_len);
+    *out = buf;
+    *out_len = (uint16_t)total;
+    return 0;
+}
+
+int pcomm_relay_plain_unpack(const uint8_t *buf, uint32_t buf_len, uint8_t *relay_cmd, uint16_t *stream_id,
+                             const uint8_t **body, uint16_t *body_len) {
+    if (!buf || buf_len < PCOMM_RELAY_HDR_LEN || !relay_cmd || !stream_id || !body || !body_len) return -1;
+    *relay_cmd = buf[0];
+    *stream_id = get_u16(buf + 1);
+    uint16_t bl = get_u16(buf + 4);
+    if (PCOMM_RELAY_HDR_LEN + bl != buf_len) return -1;
+    *body_len = bl;
+    *body = buf + PCOMM_RELAY_HDR_LEN;
+    return 0;
+}
+
+static int layer_encrypt(const uint8_t key[32], uint32_t circ_id,
+                         const uint8_t *in, uint16_t in_len,
+                         uint8_t **out, uint16_t *out_len) {
+    uint8_t nonce[12];
+    if (pcomm_random(nonce, sizeof(nonce)) != 0) return -1;
+
+    // aad = "pcomm-relay" || circ_id_be
+    uint8_t aad[16];
+    memset(aad, 0, sizeof(aad));
+    memcpy(aad, "pcomm-relay", 10);
+    uint32_t cid = htonl(circ_id);
+    memcpy(aad + 12, &cid, 4);
+
+    size_t ct_cap = (size_t)in_len + 16;
+    uint8_t *ct = (uint8_t*)malloc(ct_cap);
+    if (!ct) return -1;
+    size_t ct_len = ct_cap;
+    if (pcomm_aead_encrypt(key, nonce, aad, sizeof(aad), in, in_len, ct, &ct_len) != 0) {
+        free(ct);
+        return -1;
+    }
+
+    uint32_t total = 12 + (uint32_t)ct_len;
+    uint8_t *buf = (uint8_t*)malloc(total);
+    if (!buf) { free(ct); return -1; }
+    memcpy(buf, nonce, 12);
+    memcpy(buf + 12, ct, ct_len);
+    free(ct);
+
+    *out = buf;
+    *out_len = (uint16_t)total;
+    return 0;
+}
+
+static int layer_decrypt(const uint8_t key[32], uint32_t circ_id,
+                         const uint8_t *in, uint16_t in_len,
+                         uint8_t **out, uint16_t *out_len) {
+    if (in_len < 12 + 16) return -1;
+    const uint8_t *nonce = in;
+    const uint8_t *ct = in + 12;
+    size_t ct_len = (size_t)in_len - 12;
+
+    uint8_t aad[16];
+    memset(aad, 0, sizeof(aad));
+    memcpy(aad, "pcomm-relay", 10);
+    uint32_t cid = htonl(circ_id);
+    memcpy(aad + 12, &cid, 4);
+
+    uint8_t *pt = (uint8_t*)malloc(ct_len); // upper bound
+    if (!pt) return -1;
+    size_t pt_len = ct_len;
+    if (pcomm_aead_decrypt(key, nonce, aad, sizeof(aad), ct, ct_len, pt, &pt_len) != 0) {
+        free(pt);
+        return -1;
+    }
+    *out = pt;
+    *out_len = (uint16_t)pt_len;
+    return 0;
+}
+
+int pcomm_relay_wrap_forward(const uint8_t (*keys_fwd)[32], size_t nhops, uint32_t circ_id,
+                             const uint8_t *plain, uint16_t plain_len,
+                             uint8_t **out, uint16_t *out_len) {
+    if (!out || !out_len) return -1;
+    *out = NULL; *out_len = 0;
+    if (!keys_fwd || nhops == 0) return -1;
+
+    uint8_t *cur = (uint8_t*)malloc(plain_len);
+    if (!cur) return -1;
+    memcpy(cur, plain, plain_len);
+    uint16_t cur_len = plain_len;
+
+    for (size_t i = nhops; i-- > 0;) {
+        uint8_t *next = NULL; uint16_t next_len = 0;
+        if (layer_encrypt(keys_fwd[i], circ_id, cur, cur_len, &next, &next_len) != 0) {
+            free(cur);
+            return -1;
+        }
+        free(cur);
+        cur = next;
+        cur_len = next_len;
+    }
+
+    *out = cur;
+    *out_len = cur_len;
+    return 0;
+}
+
+int pcomm_relay_unwrap_one_forward(const uint8_t key_fwd[32], uint32_t circ_id,
+                                  const uint8_t *in, uint16_t in_len,
+                                  uint8_t **out, uint16_t *out_len) {
+    return layer_decrypt(key_fwd, circ_id, in, in_len, out, out_len);
+}
+
+int pcomm_relay_wrap_one_backward(const uint8_t key_bwd[32], uint32_t circ_id,
+                                 const uint8_t *in, uint16_t in_len,
+                                 uint8_t **out, uint16_t *out_len) {
+    return layer_encrypt(key_bwd, circ_id, in, in_len, out, out_len);
+}
+
+int pcomm_relay_unwrap_backward_all(const uint8_t (*keys_bwd)[32], size_t nhops, uint32_t circ_id,
+                                   const uint8_t *in, uint16_t in_len,
+                                   uint8_t **plain, uint16_t *plain_len) {
+    if (!plain || !plain_len) return -1;
+    *plain = NULL; *plain_len = 0;
+    if (!keys_bwd || nhops == 0) return -1;
+
+    uint8_t *cur = (uint8_t*)malloc(in_len);
+    if (!cur) return -1;
+    memcpy(cur, in, in_len);
+    uint16_t cur_len = in_len;
+
+    for (size_t i = 0; i < nhops; i++) {
+        uint8_t *next = NULL; uint16_t next_len = 0;
+        if (layer_decrypt(keys_bwd[i], circ_id, cur, cur_len, &next, &next_len) != 0) {
+            free(cur);
+            return -1;
+        }
+        free(cur);
+        cur = next;
+        cur_len = next_len;
+    }
+
+    *plain = cur;
+    *plain_len = cur_len;
+    return 0;
+}

--- a/src/cell.h
+++ b/src/cell.h
@@ -1,0 +1,53 @@
+#ifndef PCOMM_CELL_H
+#define PCOMM_CELL_H
+
+#include "pcomm.h"
+#include <stdint.h>
+#include <stddef.h>
+
+// Link-level cell header (unencrypted)
+// circ_id(4) cmd(1) flags(1) len(2)  => 8 bytes total
+#define PCOMM_CELL_HDR_LEN 8
+#define PCOMM_CELL_MAX_PAYLOAD 4096u
+
+// Build/parse link cells
+int pcomm_cell_pack(uint32_t circ_id, uint8_t cmd, uint8_t flags, const uint8_t *payload, uint16_t payload_len,
+                    uint8_t **out, uint32_t *out_len);
+
+int pcomm_cell_unpack(const uint8_t *buf, uint32_t buf_len, uint32_t *circ_id, uint8_t *cmd, uint8_t *flags,
+                      const uint8_t **payload, uint16_t *payload_len);
+
+// RELAY plaintext format (after full decryption at the exit):
+// relay_cmd(1) stream_id(2) rsv(1) body_len(2) body(...)
+#define PCOMM_RELAY_HDR_LEN 6
+
+int pcomm_relay_plain_pack(uint8_t relay_cmd, uint16_t stream_id, const uint8_t *body, uint16_t body_len,
+                           uint8_t **out, uint16_t *out_len);
+
+int pcomm_relay_plain_unpack(const uint8_t *buf, uint32_t buf_len, uint8_t *relay_cmd, uint16_t *stream_id,
+                             const uint8_t **body, uint16_t *body_len);
+
+// Onion-style layering for RELAY payloads.
+// Each layer: nonce(12) || AEAD(ct||tag) using ChaCha20-Poly1305 with aad.
+//
+// Forward direction (client -> exit): client wraps from last hop to first.
+int pcomm_relay_wrap_forward(const uint8_t (*keys_fwd)[32], size_t nhops, uint32_t circ_id,
+                             const uint8_t *plain, uint16_t plain_len,
+                             uint8_t **out, uint16_t *out_len);
+
+// Relay decrypts exactly one forward layer
+int pcomm_relay_unwrap_one_forward(const uint8_t key_fwd[32], uint32_t circ_id,
+                                  const uint8_t *in, uint16_t in_len,
+                                  uint8_t **out, uint16_t *out_len);
+
+// Return direction (exit -> client): each hop adds one layer with its bwd key.
+int pcomm_relay_wrap_one_backward(const uint8_t key_bwd[32], uint32_t circ_id,
+                                 const uint8_t *in, uint16_t in_len,
+                                 uint8_t **out, uint16_t *out_len);
+
+// Client unwraps all backward layers (first hop to last)
+int pcomm_relay_unwrap_backward_all(const uint8_t (*keys_bwd)[32], size_t nhops, uint32_t circ_id,
+                                   const uint8_t *in, uint16_t in_len,
+                                   uint8_t **plain, uint16_t *plain_len);
+
+#endif

--- a/src/circuit.c
+++ b/src/circuit.c
@@ -1,0 +1,495 @@
+#define _GNU_SOURCE
+#include "circuit.h"
+#include "net.h"
+#include "proto.h"
+#include "cell.h"
+#include "crypto.h"
+
+#include <pthread.h>
+#include <sqlite3.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <arpa/inet.h>
+
+#define PCOMM_CIRC_ID 1
+#define PCOMM_MAX_HOPS 3
+
+typedef struct {
+    uint16_t id;
+    pthread_mutex_t mu;
+    pthread_cond_t cv;
+    int done;
+    uint8_t *buf;
+    uint32_t len;
+    int saw_end;
+    int err;
+} stream_wait_t;
+
+struct pcomm_circuit {
+    int fd; // connection to guard
+    pcomm_peer_t path[PCOMM_MAX_HOPS];
+    size_t nhops;
+    uint8_t fwd[PCOMM_MAX_HOPS][32];
+    uint8_t bwd[PCOMM_MAX_HOPS][32];
+
+    pthread_t rx_thread;
+    pthread_mutex_t mu;
+    uint16_t next_stream;
+
+    // very small stream map (prototype)
+    stream_wait_t *streams[256]; // index by low byte
+    int running;
+};
+
+static pthread_t g_mgr_th;
+static pthread_mutex_t g_mgr_mu = PTHREAD_MUTEX_INITIALIZER;
+static pcomm_circuit_t *g_circ = NULL;
+static pcomm_config_t g_cfg;
+static pcomm_identity_t g_me;
+static pcomm_db_t *g_db = NULL;
+
+static void stream_wait_init(stream_wait_t *w, uint16_t id) {
+    memset(w, 0, sizeof(*w));
+    w->id = id;
+    pthread_mutex_init(&w->mu, NULL);
+    pthread_cond_init(&w->cv, NULL);
+}
+
+static void stream_wait_destroy(stream_wait_t *w) {
+    pthread_mutex_destroy(&w->mu);
+    pthread_cond_destroy(&w->cv);
+    free(w->buf);
+    w->buf = NULL;
+}
+
+static void stream_deliver(stream_wait_t *w, const uint8_t *data, uint16_t len, int is_end) {
+    pthread_mutex_lock(&w->mu);
+    if (w->done) {
+        pthread_mutex_unlock(&w->mu);
+        return;
+    }
+    if (data && len) {
+        uint8_t *nb = (uint8_t*)realloc(w->buf, w->len + len);
+        if (!nb) {
+            w->err = 1;
+            w->done = 1;
+            pthread_cond_broadcast(&w->cv);
+            pthread_mutex_unlock(&w->mu);
+            return;
+        }
+        w->buf = nb;
+        memcpy(w->buf + w->len, data, len);
+        w->len += len;
+    }
+    if (is_end) {
+        w->saw_end = 1;
+        w->done = 1;
+    }
+    pthread_cond_broadcast(&w->cv);
+    pthread_mutex_unlock(&w->mu);
+}
+
+static int db_pick_relays(pcomm_db_t *db, const char *exclude_uid, pcomm_peer_t out[PCOMM_MAX_HOPS], size_t *out_len) {
+    *out_len = 0;
+    const char *sql =
+        "SELECT user_id, host, port, pubkey FROM contacts "
+        "WHERE is_relay=1 AND host!='' AND port>0 AND user_id != ? "
+        "ORDER BY RANDOM() LIMIT 3;";
+
+    sqlite3_stmt *st = NULL;
+    if (sqlite3_prepare_v2(db->db, sql, -1, &st, NULL) != SQLITE_OK) return -1;
+    sqlite3_bind_text(st, 1, exclude_uid ? exclude_uid : "", -1, SQLITE_TRANSIENT);
+
+    while (sqlite3_step(st) == SQLITE_ROW) {
+        const char *uid = (const char*)sqlite3_column_text(st, 0);
+        const char *host = (const char*)sqlite3_column_text(st, 1);
+        int port = sqlite3_column_int(st, 2);
+        const void *pk = sqlite3_column_blob(st, 3);
+        int pklen = sqlite3_column_bytes(st, 3);
+        if (!uid || !host || pklen != 32 || port <= 0 || port > 65535) continue;
+        pcomm_peer_t *p = &out[*out_len];
+        memset(p, 0, sizeof(*p));
+        snprintf(p->user_id, sizeof(p->user_id), "%s", uid);
+        snprintf(p->host, sizeof(p->host), "%s", host);
+        p->port = (uint16_t)port;
+        memcpy(p->pubkey, pk, 32);
+        (*out_len)++;
+        if (*out_len >= PCOMM_MAX_HOPS) break;
+    }
+
+    sqlite3_finalize(st);
+    return (*out_len > 0) ? 0 : -1;
+}
+
+static int derive_hop_keys(const uint8_t shared[32], uint8_t out_fwd[32], uint8_t out_bwd[32]) {
+    const uint8_t salt[] = "pcomm-circ-v1";
+    const uint8_t info[] = "pcomm-hop-keys";
+    uint8_t okm[64];
+    if (pcomm_hkdf_sha256(shared, 32, salt, sizeof(salt)-1, info, sizeof(info)-1, okm, sizeof(okm)) != 0) return -1;
+    memcpy(out_fwd, okm, 32);
+    memcpy(out_bwd, okm + 32, 32);
+    return 0;
+}
+
+static int send_cell(int fd, uint8_t cell_cmd, const uint8_t *cell_payload, uint16_t cell_pl_len) {
+    uint8_t *cell = NULL; uint32_t cell_len = 0;
+    if (pcomm_cell_pack(PCOMM_CIRC_ID, cell_cmd, 0, cell_payload, cell_pl_len, &cell, &cell_len) != 0) return -1;
+    int rc = pcomm_send_packet(fd, PCOMM_MSG_CELL, NULL, cell, cell_len);
+    free(cell);
+    return rc;
+}
+
+static int recv_cell(int fd, uint8_t *cell_cmd, uint8_t **cell_payload, uint16_t *cell_pl_len) {
+    *cell_payload = NULL; *cell_pl_len = 0; *cell_cmd = 0;
+    pcomm_msg_type_t t; uint8_t eph[32]; uint8_t *p = NULL; uint32_t pl = 0;
+    if (pcomm_recv_packet(fd, &t, eph, &p, &pl) != 0) { free(p); return -1; }
+    if (t != PCOMM_MSG_CELL) { free(p); return -1; }
+
+    uint32_t cid; uint8_t cmd, flags; const uint8_t *cpl; uint16_t cpll;
+    if (pcomm_cell_unpack(p, pl, &cid, &cmd, &flags, &cpl, &cpll) != 0 || cid != PCOMM_CIRC_ID) {
+        free(p);
+        return -1;
+    }
+    (void)flags;
+    *cell_cmd = cmd;
+    if (cpll) {
+        uint8_t *cp = (uint8_t*)malloc(cpll);
+        if (!cp) { free(p); return -1; }
+        memcpy(cp, cpl, cpll);
+        *cell_payload = cp;
+        *cell_pl_len = cpll;
+    }
+    free(p);
+    return 0;
+}
+
+static int send_relay_plain_locked(pcomm_circuit_t *c, const uint8_t *plain, uint16_t plain_len) {
+    uint8_t *wrapped = NULL; uint16_t wrapped_len = 0;
+    if (pcomm_relay_wrap_forward(c->fwd, c->nhops, PCOMM_CIRC_ID, plain, plain_len, &wrapped, &wrapped_len) != 0) {
+        return -1;
+    }
+    int rc = send_cell(c->fd, PCOMM_CELL_RELAY, wrapped, wrapped_len);
+    free(wrapped);
+    return rc;
+}
+
+static void *rx_loop(void *arg) {
+    pcomm_circuit_t *c = (pcomm_circuit_t*)arg;
+    while (c->running) {
+        pcomm_msg_type_t t; uint8_t eph[32]; uint8_t *p=NULL; uint32_t pl=0;
+        if (pcomm_recv_packet(c->fd, &t, eph, &p, &pl) != 0) {
+            free(p);
+            break;
+        }
+        if (t != PCOMM_MSG_CELL) { free(p); continue; }
+        uint32_t cid; uint8_t cmd, flags; const uint8_t *cpl; uint16_t cpll;
+        if (pcomm_cell_unpack(p, pl, &cid, &cmd, &flags, &cpl, &cpll) != 0 || cid != PCOMM_CIRC_ID) {
+            free(p);
+            continue;
+        }
+        (void)flags;
+        if (cmd == PCOMM_CELL_RELAY) {
+            uint8_t *plain = NULL; uint16_t plain_len = 0;
+            if (pcomm_relay_unwrap_backward_all(c->bwd, c->nhops, PCOMM_CIRC_ID, cpl, cpll, &plain, &plain_len) == 0) {
+                uint8_t rcmd; uint16_t sid; const uint8_t *body; uint16_t bl;
+                if (pcomm_relay_plain_unpack(plain, plain_len, &rcmd, &sid, &body, &bl) == 0) {
+                    pthread_mutex_lock(&c->mu);
+                    stream_wait_t *w = c->streams[sid & 0xFF];
+                    pthread_mutex_unlock(&c->mu);
+                    if (w && w->id == sid) {
+                        if (rcmd == PCOMM_RELAY_DATA) {
+                            stream_deliver(w, body, bl, 0);
+                        } else if (rcmd == PCOMM_RELAY_END) {
+                            stream_deliver(w, NULL, 0, 1);
+                        } else if (rcmd == PCOMM_RELAY_CONNECTED) {
+                            // ignore for now
+                        }
+                    }
+                }
+                free(plain);
+            }
+        }
+        free(p);
+    }
+
+    // fail all waiters
+    pthread_mutex_lock(&c->mu);
+    for (int i=0;i<256;i++) {
+        stream_wait_t *w = c->streams[i];
+        if (w) stream_deliver(w, NULL, 0, 1);
+    }
+    pthread_mutex_unlock(&c->mu);
+    return NULL;
+}
+
+static int circuit_build(pcomm_circuit_t *c, const pcomm_peer_t *path, size_t path_len) {
+    memset(c, 0, sizeof(*c));
+    pthread_mutex_init(&c->mu, NULL);
+    c->next_stream = 1;
+
+    c->fd = net_connect_tcp(path[0].host, path[0].port);
+    if (c->fd < 0) return -1;
+
+    // hop1 CREATE
+    uint8_t eph1_priv[32], eph1_pub[32];
+    if (pcomm_random(eph1_priv, 32) != 0) return -1;
+    // OpenSSL X25519 expects clamped; EVP does.
+    // We'll use pcomm_x25519_derive with basepoint to get pub? Not available.
+    // Quick hack: use OpenSSL directly via pcomm_x25519_derive is shared only.
+    // Instead, generate keypair via OpenSSL in crypto.c in a helper. For now, derive pub by X25519(priv, basepoint).
+    static const uint8_t basepoint[32] = {9};
+    if (pcomm_x25519_derive(eph1_priv, basepoint, eph1_pub) != 0) return -1;
+
+    if (send_cell(c->fd, PCOMM_CELL_CREATE, eph1_pub, 32) != 0) return -1;
+
+    uint8_t rcmd; uint8_t *rpl=NULL; uint16_t rpll=0;
+    if (recv_cell(c->fd, &rcmd, &rpl, &rpll) != 0 || rcmd != PCOMM_CELL_CREATED || rpll != 32) {
+        free(rpl);
+        return -1;
+    }
+    uint8_t shared1[32];
+    if (pcomm_x25519_derive(eph1_priv, rpl, shared1) != 0) { free(rpl); return -1; }
+    free(rpl);
+    if (derive_hop_keys(shared1, c->fwd[0], c->bwd[0]) != 0) return -1;
+
+    c->path[0] = path[0];
+    c->nhops = 1;
+
+    // extend further hops
+    for (size_t hi=1; hi<path_len; hi++) {
+        uint8_t eph_priv[32], eph_pub[32];
+        if (pcomm_random(eph_priv, 32) != 0) return -1;
+        if (pcomm_x25519_derive(eph_priv, basepoint, eph_pub) != 0) return -1;
+
+        // body: hostlen(1) host port(2) eph_pub(32)
+        uint8_t body[1+64+2+32];
+        size_t hostlen = strlen(path[hi].host);
+        if (hostlen == 0 || hostlen > 63) return -1;
+        size_t bo = 0;
+        body[bo++] = (uint8_t)hostlen;
+        memcpy(body+bo, path[hi].host, hostlen); bo += hostlen;
+        uint16_t p = htons(path[hi].port);
+        memcpy(body+bo, &p, 2); bo += 2;
+        memcpy(body+bo, eph_pub, 32); bo += 32;
+
+        uint8_t *plain=NULL; uint16_t plain_len=0;
+        if (pcomm_relay_plain_pack(PCOMM_RELAY_EXTEND, 0, body, (uint16_t)bo, &plain, &plain_len) != 0) return -1;
+
+        pthread_mutex_lock(&c->mu);
+        int rc = send_relay_plain_locked(c, plain, plain_len);
+        pthread_mutex_unlock(&c->mu);
+        free(plain);
+        if (rc != 0) return -1;
+
+        // Wait for EXTENDED on stream 0 (we'll treat it specially: receiver doesn't dispatch stream 0)
+        // For prototype, do a blocking read here: receive one cell and decrypt fully.
+        pcomm_msg_type_t t; uint8_t eph[32]; uint8_t *pp=NULL; uint32_t ppl=0;
+        if (pcomm_recv_packet(c->fd, &t, eph, &pp, &ppl) != 0) { free(pp); return -1; }
+        if (t != PCOMM_MSG_CELL) { free(pp); return -1; }
+        uint32_t cid; uint8_t cmd, flags; const uint8_t *cpl; uint16_t cpll;
+        if (pcomm_cell_unpack(pp, ppl, &cid, &cmd, &flags, &cpl, &cpll) != 0 || cid != PCOMM_CIRC_ID || cmd != PCOMM_CELL_RELAY) {
+            free(pp);
+            return -1;
+        }
+        (void)flags;
+        uint8_t *ext_plain=NULL; uint16_t ext_plain_len=0;
+        if (pcomm_relay_unwrap_backward_all(c->bwd, c->nhops, PCOMM_CIRC_ID, cpl, cpll, &ext_plain, &ext_plain_len) != 0) {
+            free(pp);
+            return -1;
+        }
+        free(pp);
+        uint8_t rr; uint16_t sid; const uint8_t *bdy; uint16_t bl;
+        if (pcomm_relay_plain_unpack(ext_plain, ext_plain_len, &rr, &sid, &bdy, &bl) != 0 || rr != PCOMM_RELAY_EXTENDED || bl != 32) {
+            free(ext_plain);
+            return -1;
+        }
+        uint8_t shared[32];
+        if (pcomm_x25519_derive(eph_priv, bdy, shared) != 0) { free(ext_plain); return -1; }
+        free(ext_plain);
+
+        if (derive_hop_keys(shared, c->fwd[c->nhops], c->bwd[c->nhops]) != 0) return -1;
+        c->path[c->nhops] = path[hi];
+        c->nhops++;
+    }
+
+    c->running = 1;
+    if (pthread_create(&c->rx_thread, NULL, rx_loop, c) != 0) return -1;
+
+    return 0;
+}
+
+static void circuit_free(pcomm_circuit_t *c) {
+    if (!c) return;
+    c->running = 0;
+    if (c->fd >= 0) close(c->fd);
+    if (c->rx_thread) pthread_join(c->rx_thread, NULL);
+    pthread_mutex_destroy(&c->mu);
+    free(c);
+}
+
+static void *mgr_loop(void *arg) {
+    (void)arg;
+    while (1) {
+        pthread_mutex_lock(&g_mgr_mu);
+        pcomm_circuit_t *cur = g_circ;
+        pthread_mutex_unlock(&g_mgr_mu);
+
+        if (!cur) {
+            // Build a circuit
+            pcomm_peer_t path[PCOMM_MAX_HOPS]; size_t path_len=0;
+            if (db_pick_relays(g_db, g_me.user_id, path, &path_len) == 0) {
+                // Ensure at least 1 hop
+                pcomm_circuit_t *nc = (pcomm_circuit_t*)calloc(1, sizeof(pcomm_circuit_t));
+                if (nc) {
+                    if (circuit_build(nc, path, path_len) == 0) {
+                        pthread_mutex_lock(&g_mgr_mu);
+                        g_circ = nc;
+                        pthread_mutex_unlock(&g_mgr_mu);
+                        fprintf(stderr, "[circuit] built %zu-hop circuit via %s\n", path_len, path[0].user_id);
+                    } else {
+                        circuit_free(nc);
+                    }
+                }
+            }
+        } else {
+            // keepalive padding every ~10s
+            uint8_t z=0;
+            send_cell(cur->fd, PCOMM_CELL_PADDING, &z, 1);
+        }
+
+        sleep(10);
+    }
+    return NULL;
+}
+
+int pcomm_circuits_start(const pcomm_config_t *cfg, const pcomm_identity_t *me, pcomm_db_t *db) {
+    if (!cfg || !me || !db) return -1;
+    g_cfg = *cfg;
+    g_me = *me;
+    g_db = db;
+    if (pthread_create(&g_mgr_th, NULL, mgr_loop, NULL) != 0) return -1;
+    return 0;
+}
+
+pcomm_circuit_t *pcomm_circuit_get(void) {
+    pthread_mutex_lock(&g_mgr_mu);
+    pcomm_circuit_t *c = g_circ;
+    pthread_mutex_unlock(&g_mgr_mu);
+    return c;
+}
+
+static uint16_t alloc_stream_id(pcomm_circuit_t *c) {
+    uint16_t sid = c->next_stream++;
+    if (sid == 0) sid = c->next_stream++;
+    return sid;
+}
+
+int pcomm_circuit_rpc(pcomm_circuit_t *c,
+                      const char *dest_host, uint16_t dest_port,
+                      pcomm_msg_type_t inner_type,
+                      const uint8_t *inner_payload, uint32_t inner_payload_len,
+                      int expect_resp,
+                      pcomm_msg_type_t *resp_type_out,
+                      uint8_t **resp_payload_out, uint32_t *resp_payload_len_out) {
+    if (resp_payload_out) *resp_payload_out = NULL;
+    if (resp_payload_len_out) *resp_payload_len_out = 0;
+    if (resp_type_out) *resp_type_out = 0;
+    if (!c || !dest_host || dest_port == 0) return -1;
+
+    uint8_t *inner = NULL; uint32_t inner_len = 0;
+    if (pcomm_pack_packet(inner_type, NULL, inner_payload, inner_payload_len, &inner, &inner_len) != 0) return -1;
+
+    pthread_mutex_lock(&c->mu);
+    uint16_t sid = alloc_stream_id(c);
+
+    stream_wait_t w;
+    stream_wait_init(&w, sid);
+    c->streams[sid & 0xFF] = &w;
+
+    // BEGIN body: hostlen(1) host port(2) expect(1)
+    uint8_t b[1+64+2+1];
+    size_t hl = strlen(dest_host);
+    if (hl == 0 || hl > 63) { c->streams[sid & 0xFF] = NULL; pthread_mutex_unlock(&c->mu); free(inner); return -1; }
+    size_t bo = 0;
+    b[bo++] = (uint8_t)hl;
+    memcpy(b+bo, dest_host, hl); bo += hl;
+    uint16_t np = htons(dest_port);
+    memcpy(b+bo, &np, 2); bo += 2;
+    b[bo++] = (uint8_t)(expect_resp ? 1 : 0);
+
+    uint8_t *plain=NULL; uint16_t plain_len=0;
+    if (pcomm_relay_plain_pack(PCOMM_RELAY_BEGIN, sid, b, (uint16_t)bo, &plain, &plain_len) != 0) {
+        c->streams[sid & 0xFF] = NULL;
+        pthread_mutex_unlock(&c->mu);
+        free(inner);
+        return -1;
+    }
+    int rc = send_relay_plain_locked(c, plain, plain_len);
+    free(plain);
+    if (rc != 0) {
+        c->streams[sid & 0xFF] = NULL;
+        pthread_mutex_unlock(&c->mu);
+        free(inner);
+        stream_wait_destroy(&w);
+        return -1;
+    }
+
+    // DATA body: inner packet bytes
+    if (pcomm_relay_plain_pack(PCOMM_RELAY_DATA, sid, inner, (uint16_t)inner_len, &plain, &plain_len) != 0) {
+        c->streams[sid & 0xFF] = NULL;
+        pthread_mutex_unlock(&c->mu);
+        free(inner);
+        stream_wait_destroy(&w);
+        return -1;
+    }
+    rc = send_relay_plain_locked(c, plain, plain_len);
+    free(plain);
+    free(inner);
+
+    // END
+    pcomm_relay_plain_pack(PCOMM_RELAY_END, sid, NULL, 0, &plain, &plain_len);
+    if (plain) {
+        send_relay_plain_locked(c, plain, plain_len);
+        free(plain);
+    }
+
+    pthread_mutex_unlock(&c->mu);
+
+    if (!expect_resp) {
+        pthread_mutex_lock(&c->mu);
+        c->streams[sid & 0xFF] = NULL;
+        pthread_mutex_unlock(&c->mu);
+        stream_wait_destroy(&w);
+        return 0;
+    }
+
+    // Wait
+    pthread_mutex_lock(&w.mu);
+    while (!w.done) pthread_cond_wait(&w.cv, &w.mu);
+    pthread_mutex_unlock(&w.mu);
+
+    pthread_mutex_lock(&c->mu);
+    c->streams[sid & 0xFF] = NULL;
+    pthread_mutex_unlock(&c->mu);
+
+    if (w.err || !w.saw_end || w.len == 0) {
+        stream_wait_destroy(&w);
+        return -1;
+    }
+
+    pcomm_msg_type_t rt; uint8_t reph[32]; uint8_t *rp=NULL; uint32_t rpl=0;
+    if (pcomm_unpack_packet(w.buf, w.len, &rt, reph, &rp, &rpl) != 0) {
+        stream_wait_destroy(&w);
+        return -1;
+    }
+
+    if (resp_type_out) *resp_type_out = rt;
+    if (resp_payload_out) *resp_payload_out = rp; else free(rp);
+    if (resp_payload_len_out) *resp_payload_len_out = rpl;
+
+    stream_wait_destroy(&w);
+    return 0;
+}

--- a/src/circuit.h
+++ b/src/circuit.h
@@ -1,0 +1,28 @@
+#ifndef PCOMM_CIRCUIT_H
+#define PCOMM_CIRCUIT_H
+
+#include "pcomm.h"
+#include "db.h"
+#include <stdint.h>
+#include <stddef.h>
+
+typedef struct pcomm_circuit pcomm_circuit_t;
+
+// Start global circuit manager. It will keep at least one 3-hop circuit alive for onion-routed RPCs.
+int pcomm_circuits_start(const pcomm_config_t *cfg, const pcomm_identity_t *me, pcomm_db_t *db);
+
+// Get current circuit (may be NULL if not ready).
+pcomm_circuit_t *pcomm_circuit_get(void);
+
+// Perform a single RPC over the circuit using stream multiplexing.
+// It opens a stream to dest_host:dest_port, sends one packed PComm packet (inner_type/payload),
+// optionally waits for one response packet, then closes the stream.
+int pcomm_circuit_rpc(pcomm_circuit_t *c,
+                      const char *dest_host, uint16_t dest_port,
+                      pcomm_msg_type_t inner_type,
+                      const uint8_t *inner_payload, uint32_t inner_payload_len,
+                      int expect_resp,
+                      pcomm_msg_type_t *resp_type_out,
+                      uint8_t **resp_payload_out, uint32_t *resp_payload_len_out);
+
+#endif

--- a/src/config.c
+++ b/src/config.c
@@ -31,7 +31,7 @@ void pcomm_config_defaults(pcomm_config_t *cfg) {
 
 static void usage(const char *argv0) {
     fprintf(stderr,
-        "PComm - the other one (prototype)\n\n"
+        "PComm - minimal onion-relay messenger (prototype)\n\n"
         "Usage: %s [options]\n\n"
         "Options:\n"
         "  --data-dir PATH     Data directory (default ./pcomm_data)\n"

--- a/src/config.h
+++ b/src/config.h
@@ -4,6 +4,8 @@
 #include "pcomm.h"
 
 void pcomm_config_defaults(pcomm_config_t *cfg);
+
+// Parses argv; returns 0 on success.
 int pcomm_config_from_argv(pcomm_config_t *cfg, int argc, char **argv);
 
 #endif

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -226,7 +226,7 @@ int pcomm_open_seal(const uint8_t recipient_priv[32],
     const uint8_t info[] = "pcomm-seal-v1";
     if (pcomm_hkdf_sha256(shared, sizeof(shared), NULL, 0, info, sizeof(info)-1, key, sizeof(key)) != 0) return -1;
 
-    uint8_t *pt = (uint8_t*)malloc(ct_len);
+    uint8_t *pt = (uint8_t*)malloc(ct_len); // upper bound
     if (!pt) return -1;
     size_t pt_len = ct_len;
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -4,11 +4,16 @@
 #include <stddef.h>
 #include <stdint.h>
 
+// Derive shared secret: X25519(priv(32), pub(32)) -> out(32). Returns 0 on success.
 int pcomm_x25519_derive(const uint8_t priv[32], const uint8_t pub[32], uint8_t out_shared[32]);
+
+// HKDF-SHA256 to derive key material.
 int pcomm_hkdf_sha256(const uint8_t *ikm, size_t ikm_len,
                       const uint8_t *salt, size_t salt_len,
                       const uint8_t *info, size_t info_len,
                       uint8_t *out, size_t out_len);
+
+// AEAD ChaCha20-Poly1305 (IETF 96-bit nonce). Tag is appended to ciphertext.
 int pcomm_aead_encrypt(const uint8_t key[32], const uint8_t nonce[12],
                        const uint8_t *aad, size_t aad_len,
                        const uint8_t *pt, size_t pt_len,
@@ -19,11 +24,16 @@ int pcomm_aead_decrypt(const uint8_t key[32], const uint8_t nonce[12],
                        const uint8_t *ct, size_t ct_len,
                        uint8_t *pt_out, size_t *pt_len_inout);
 
+// Random bytes
 int pcomm_random(uint8_t *buf, size_t len);
+
+// Sealed-box style: encrypt for recipient pubkey.
+// Output format: eph_pub(32) || nonce(12) || ciphertext||tag
 int pcomm_seal_for_recipient(const uint8_t recipient_pub[32],
                              const uint8_t *msg, size_t msg_len,
                              uint8_t **out, size_t *out_len);
 
+// Decrypt sealed box using recipient priv.
 int pcomm_open_seal(const uint8_t recipient_priv[32],
                     const uint8_t *sealed, size_t sealed_len,
                     uint8_t **out_msg, size_t *out_msg_len);

--- a/src/db.c
+++ b/src/db.c
@@ -43,6 +43,7 @@ int pcomm_db_open(pcomm_db_t *pdb, const char *data_dir) {
     }
     sqlite3_busy_timeout(pdb->db, 2000);
 
+    // enforce foreign keys
     exec_sql(pdb->db, "PRAGMA foreign_keys=ON;");
     return 0;
 }
@@ -68,7 +69,7 @@ int pcomm_db_init_schema(pcomm_db_t *pdb) {
         "CREATE TABLE IF NOT EXISTS conversations("
         " id INTEGER PRIMARY KEY AUTOINCREMENT,"
         " uuid TEXT,"
-        " type TEXT NOT NULL,"
+        " type TEXT NOT NULL," // 'direct' or 'group'
         " title TEXT,"
         " created_at INTEGER NOT NULL"
         ");"
@@ -83,8 +84,8 @@ int pcomm_db_init_schema(pcomm_db_t *pdb) {
         "CREATE TABLE IF NOT EXISTS messages("
         " id INTEGER PRIMARY KEY AUTOINCREMENT,"
         " conversation_id INTEGER NOT NULL,"
-        " direction INTEGER NOT NULL,"
-        " peer_user_id TEXT NOT NULL,"
+        " direction INTEGER NOT NULL," // 0=in, 1=out
+        " peer_user_id TEXT NOT NULL," // other party for direct chats
         " sender_user_id TEXT NOT NULL,"
         " body TEXT NOT NULL,"
         " ciphertext BLOB NOT NULL,"
@@ -95,10 +96,14 @@ int pcomm_db_init_schema(pcomm_db_t *pdb) {
         "CREATE INDEX IF NOT EXISTS idx_messages_conv_ts ON messages(conversation_id, ts_unix);";
 
     if (exec_sql(pdb->db, sql) != 0) return -1;
+
+    // Migrations for older databases
     if (!column_exists(pdb->db, "conversations", "uuid")) {
         if (exec_sql(pdb->db, "ALTER TABLE conversations ADD COLUMN uuid TEXT;") != 0) return -1;
         exec_sql(pdb->db, "CREATE UNIQUE INDEX IF NOT EXISTS idx_conversations_uuid ON conversations(uuid);");
     }
+
+    // Relay-side storage for mailbox + descriptors (used for intro/hsdir style rendezvous)
     const char *sql2 =
         "CREATE TABLE IF NOT EXISTS mailbox_items("
         " id INTEGER PRIMARY KEY AUTOINCREMENT,"
@@ -185,6 +190,7 @@ static int64_t now_unix(sqlite3 *db) {
 }
 
 static uint64_t to_be64(uint64_t x) {
+    // portable host->big endian
     uint8_t b[8];
     b[0] = (uint8_t)((x >> 56) & 0xFF);
     b[1] = (uint8_t)((x >> 48) & 0xFF);
@@ -201,6 +207,8 @@ static uint64_t to_be64(uint64_t x) {
 
 int64_t pcomm_db_get_or_create_direct_conv(pcomm_db_t *pdb, const char *peer_user_id) {
     if (!pdb || !pdb->db) return -1;
+
+    // Find existing direct conversation containing peer
     const char *find_sql =
         "SELECT c.id FROM conversations c "
         "JOIN participants p ON p.conversation_id=c.id "
@@ -216,6 +224,8 @@ int64_t pcomm_db_get_or_create_direct_conv(pcomm_db_t *pdb, const char *peer_use
         return id;
     }
     sqlite3_finalize(st);
+
+    // create new conversation and participant
     exec_sql(pdb->db, "BEGIN;");
 
     sqlite3_stmt *ins = NULL;
@@ -395,6 +405,8 @@ int pcomm_db_mailbox_put(pcomm_db_t *pdb, const uint8_t key[32], const uint8_t *
     return (rc == SQLITE_DONE) ? 0 : -1;
 }
 
+// Returns a packed MB_RESP body (without the leading cmd byte):
+// count(u16) [ id(u64) ts(u32) len(u32) blob ... ]*
 int pcomm_db_mailbox_get_and_delete(pcomm_db_t *pdb, const uint8_t key[32], uint8_t **out, uint32_t *out_len) {
     if (!pdb || !pdb->db || !key || !out || !out_len) return -1;
     *out = NULL; *out_len = 0;
@@ -408,6 +420,8 @@ int pcomm_db_mailbox_get_and_delete(pcomm_db_t *pdb, const uint8_t key[32], uint
         return -1;
     }
     sqlite3_bind_blob(st, 1, key, 32, SQLITE_TRANSIENT);
+
+    // First pass: count and size
     int count = 0;
     uint64_t ids[100];
     int64_t tss[100];
@@ -422,6 +436,8 @@ int pcomm_db_mailbox_get_and_delete(pcomm_db_t *pdb, const uint8_t key[32], uint
         count++;
     }
     sqlite3_finalize(st);
+
+    // Compute output size
     uint32_t total = 2;
     for (int i = 0; i < count; i++) {
         total += 8 + 4 + 4 + (uint32_t)blens[i];
@@ -432,6 +448,7 @@ int pcomm_db_mailbox_get_and_delete(pcomm_db_t *pdb, const uint8_t key[32], uint
         exec_sql(pdb->db, "ROLLBACK;");
         return -1;
     }
+    // pack
     uint16_t ncount = (uint16_t)count;
     uint16_t n = htons(ncount);
     memcpy(buf, &n, 2);
@@ -446,7 +463,9 @@ int pcomm_db_mailbox_get_and_delete(pcomm_db_t *pdb, const uint8_t key[32], uint
         memcpy(buf + off, blobs[i], (size_t)blens[i]); off += (uint32_t)blens[i];
     }
 
+    // delete returned items
     if (count > 0) {
+        // Build a simple delete with range (id <= max_id) + key, since we always return oldest.
         uint64_t max_id = ids[count-1];
         sqlite3_stmt *del = NULL;
         if (sqlite3_prepare_v2(pdb->db, "DELETE FROM mailbox_items WHERE mkey=? AND id<=?;", -1, &del, NULL) == SQLITE_OK) {

--- a/src/db.h
+++ b/src/db.h
@@ -24,11 +24,13 @@ int pcomm_db_insert_message(pcomm_db_t *pdb, int64_t conv_id, int direction, con
                             const uint8_t *cipher, size_t cipher_len,
                             int64_t ts_unix);
 
+// Group support helpers
 int64_t pcomm_db_get_or_create_group_conv(pcomm_db_t *pdb, const char *uuid, const char *title);
 int pcomm_db_add_participant(pcomm_db_t *pdb, int64_t conv_id, const char *user_id);
 int pcomm_db_get_conversation_uuid(pcomm_db_t *pdb, int64_t conv_id, char *uuid_out, size_t uuid_cap, char *type_out, size_t type_cap);
 int pcomm_db_list_group_participants(pcomm_db_t *pdb, int64_t conv_id, char ***ids_out, int *count_out);
 
+// Relay mailbox / descriptor storage (used when acting as a relay).
 int pcomm_db_mailbox_put(pcomm_db_t *pdb, const uint8_t key[32], const uint8_t *blob, uint32_t blob_len, int64_t ts_unix);
 int pcomm_db_mailbox_get_and_delete(pcomm_db_t *pdb, const uint8_t key[32], uint8_t **out, uint32_t *out_len);
 int pcomm_db_desc_put(pcomm_db_t *pdb, const uint8_t key[32], const uint8_t *blob, uint32_t blob_len, int64_t expires_unix, int64_t ts_unix);

--- a/src/dht.c
+++ b/src/dht.c
@@ -1,0 +1,645 @@
+#define _GNU_SOURCE
+#include "dht.h"
+#include "bencode.h"
+#include "crypto.h"
+
+#include <pthread.h>
+#include <openssl/sha.h>
+#include <sqlite3.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <errno.h>
+
+#define DHT_MAX_NODES 512
+#define DHT_QUERY_FANOUT 24
+#define DHT_MAX_QUERIES 64
+
+typedef struct {
+    uint8_t id[20];
+    struct sockaddr_in addr;
+    time_t last_seen;
+} dht_node_t;
+
+typedef struct peer_item {
+    uint8_t infohash[20];
+    uint8_t *peers; // compact peers concatenated (6*n)
+    size_t peers_len;
+    struct peer_item *next;
+} peer_item_t;
+
+typedef struct {
+    uint16_t tx;
+    int used;
+    int done;
+    benc_t *resp;
+    pthread_cond_t cv;
+} pending_t;
+
+typedef struct {
+    int udp_fd;
+    uint8_t node_id[20];
+    uint8_t secret[20];
+    uint16_t listen_port;
+
+    pthread_t th;
+    pthread_mutex_t mu;
+
+    dht_node_t nodes[DHT_MAX_NODES];
+    size_t nodes_len;
+
+    peer_item_t *peers_head;
+
+    pending_t pending[DHT_MAX_QUERIES];
+
+    pcomm_db_t *db;
+} dht_state_t;
+
+static dht_state_t *g_dht = NULL;
+
+static void sha1_bytes(const uint8_t *in, size_t in_len, uint8_t out20[20]) {
+    SHA_CTX c;
+    SHA1_Init(&c);
+    SHA1_Update(&c, in, in_len);
+    SHA1_Final(out20, &c);
+}
+
+void pcomm_dht_infohash_desc(const char *user_id, uint8_t out20[20]) {
+    // BEP-5 uses SHA1 infohash; we scope ours with a tag.
+    uint8_t buf[256];
+    size_t n = 0;
+    const char *tag = "pcomm-desc:";
+    memcpy(buf + n, tag, strlen(tag)); n += strlen(tag);
+    memcpy(buf + n, user_id, strlen(user_id)); n += strlen(user_id);
+    sha1_bytes(buf, n, out20);
+}
+
+void pcomm_dht_infohash_mb(const char *user_id, uint8_t out20[20]) {
+    uint8_t buf[256];
+    size_t n = 0;
+    const char *tag = "pcomm-mb:";
+    memcpy(buf + n, tag, strlen(tag)); n += strlen(tag);
+    memcpy(buf + n, user_id, strlen(user_id)); n += strlen(user_id);
+    sha1_bytes(buf, n, out20);
+}
+
+static void compute_node_id(const pcomm_identity_t *me, uint8_t out20[20]) {
+    // DHT node id derived from identity pubkey (stable) + tag.
+    uint8_t buf[64];
+    memcpy(buf, "pcomm-dht", 9);
+    memcpy(buf + 9, me->pubkey, 32);
+    sha1_bytes(buf, 41, out20);
+}
+
+static void token_for_ip(const uint8_t secret[20], const struct sockaddr_in *addr, uint8_t out4[4]) {
+    // token = first 4 bytes of SHA1(secret || ip || timebucket)
+    uint8_t buf[64];
+    size_t n = 0;
+    memcpy(buf + n, secret, 20); n += 20;
+    memcpy(buf + n, &addr->sin_addr, 4); n += 4;
+    uint32_t bucket = (uint32_t)(time(NULL) / 300); // 5 minutes
+    bucket = htonl(bucket);
+    memcpy(buf + n, &bucket, 4); n += 4;
+    uint8_t h[20];
+    sha1_bytes(buf, n, h);
+    memcpy(out4, h, 4);
+}
+
+static int addr_eq(const struct sockaddr_in *a, const struct sockaddr_in *b) {
+    return a->sin_addr.s_addr == b->sin_addr.s_addr && a->sin_port == b->sin_port;
+}
+
+static void add_node_locked(dht_state_t *st, const uint8_t id[20], const struct sockaddr_in *addr) {
+    if (!addr || addr->sin_port == 0) return;
+    // ignore 0.0.0.0
+    if (addr->sin_addr.s_addr == 0) return;
+
+    for (size_t i=0;i<st->nodes_len;i++) {
+        if (addr_eq(&st->nodes[i].addr, addr)) {
+            if (id) memcpy(st->nodes[i].id, id, 20);
+            st->nodes[i].last_seen = time(NULL);
+            return;
+        }
+    }
+    if (st->nodes_len >= DHT_MAX_NODES) return;
+    dht_node_t *n = &st->nodes[st->nodes_len++];
+    memset(n, 0, sizeof(*n));
+    if (id) memcpy(n->id, id, 20);
+    n->addr = *addr;
+    n->last_seen = time(NULL);
+}
+
+static void peers_add_locked(dht_state_t *st, const uint8_t infohash[20], const uint8_t compact6[6]) {
+    // find bucket by first byte
+    peer_item_t *it = st->peers_head;
+    while (it) {
+        if (memcmp(it->infohash, infohash, 20) == 0) break;
+        it = it->next;
+    }
+    if (!it) {
+        it = (peer_item_t*)calloc(1, sizeof(peer_item_t));
+        if (!it) return;
+        memcpy(it->infohash, infohash, 20);
+        it->next = st->peers_head;
+        st->peers_head = it;
+    }
+    // dedupe
+    for (size_t i=0;i+6<=it->peers_len;i+=6) {
+        if (memcmp(it->peers + i, compact6, 6) == 0) return;
+    }
+    if (it->peers_len >= 6*64) return; // cap
+    uint8_t *nb = (uint8_t*)realloc(it->peers, it->peers_len + 6);
+    if (!nb) return;
+    it->peers = nb;
+    memcpy(it->peers + it->peers_len, compact6, 6);
+    it->peers_len += 6;
+}
+
+static int peers_get_locked(dht_state_t *st, const uint8_t infohash[20], uint8_t **out, size_t *out_len) {
+    *out = NULL; *out_len = 0;
+    peer_item_t *it = st->peers_head;
+    while (it) {
+        if (memcmp(it->infohash, infohash, 20) == 0) break;
+        it = it->next;
+    }
+    if (!it || it->peers_len == 0) return -1;
+    uint8_t *b = (uint8_t*)malloc(it->peers_len);
+    if (!b) return -1;
+    memcpy(b, it->peers, it->peers_len);
+    *out = b;
+    *out_len = it->peers_len;
+    return 0;
+}
+
+static pending_t *pending_alloc_locked(dht_state_t *st, uint16_t tx) {
+    for (int i=0;i<DHT_MAX_QUERIES;i++) {
+        if (!st->pending[i].used) {
+            st->pending[i].used = 1;
+            st->pending[i].done = 0;
+            st->pending[i].tx = tx;
+            st->pending[i].resp = NULL;
+            pthread_cond_init(&st->pending[i].cv, NULL);
+            return &st->pending[i];
+        }
+    }
+    return NULL;
+}
+
+static pending_t *pending_find_locked(dht_state_t *st, uint16_t tx) {
+    for (int i=0;i<DHT_MAX_QUERIES;i++) if (st->pending[i].used && st->pending[i].tx == tx) return &st->pending[i];
+    return NULL;
+}
+
+static void pending_free_locked(pending_t *p) {
+    if (!p) return;
+    benc_free(p->resp);
+    p->resp = NULL;
+    pthread_cond_destroy(&p->cv);
+    p->used = 0;
+    p->done = 0;
+    p->tx = 0;
+}
+
+static int send_krpc(dht_state_t *st, const struct sockaddr_in *to, const benc_t *msg) {
+    uint8_t *buf=NULL; size_t len=0;
+    if (benc_encode(msg, &buf, &len) != 0) return -1;
+    int rc = (sendto(st->udp_fd, buf, len, 0, (const struct sockaddr*)to, sizeof(*to)) == (ssize_t)len) ? 0 : -1;
+    free(buf);
+    return rc;
+}
+
+static uint16_t rand_tx(void) {
+    uint8_t r[2];
+    pcomm_random(r, 2);
+    return (uint16_t)((r[0] << 8) | r[1]);
+}
+
+static benc_t *krpc_build_query(dht_state_t *st, uint16_t tx, const char *q, benc_t *a) {
+    benc_t *m = benc_new_dict();
+    if (!m) return NULL;
+    uint8_t txb[2] = {(uint8_t)(tx>>8), (uint8_t)(tx&0xFF)};
+    benc_dict_set(m, "t", benc_new_str(txb, 2));
+    benc_dict_set(m, "y", benc_new_str((const uint8_t*)"q", 1));
+    benc_dict_set(m, "q", benc_new_str((const uint8_t*)q, strlen(q)));
+
+    if (!a) a = benc_new_dict();
+    benc_dict_set(a, "id", benc_new_str(st->node_id, 20));
+    benc_dict_set(m, "a", a);
+    return m;
+}
+
+static benc_t *krpc_build_resp(dht_state_t *st, const uint8_t txb[2], benc_t *r) {
+    benc_t *m = benc_new_dict();
+    if (!m) return NULL;
+    benc_dict_set(m, "t", benc_new_str(txb, 2));
+    benc_dict_set(m, "y", benc_new_str((const uint8_t*)"r", 1));
+    if (!r) r = benc_new_dict();
+    benc_dict_set(r, "id", benc_new_str(st->node_id, 20));
+    benc_dict_set(m, "r", r);
+    return m;
+}
+
+static void compact_nodes_locked(dht_state_t *st, uint8_t **out, size_t *out_len) {
+    // up to 8 nodes
+    size_t want = st->nodes_len < 8 ? st->nodes_len : 8;
+    size_t len = want * 26;
+    uint8_t *b = (uint8_t*)malloc(len);
+    if (!b) { *out=NULL; *out_len=0; return; }
+    size_t o=0;
+    for (size_t i=0;i<want;i++) {
+        memcpy(b+o, st->nodes[i].id, 20); o+=20;
+        memcpy(b+o, &st->nodes[i].addr.sin_addr, 4); o+=4;
+        memcpy(b+o, &st->nodes[i].addr.sin_port, 2); o+=2;
+    }
+    *out = b;
+    *out_len = len;
+}
+
+static void handle_query(dht_state_t *st, const struct sockaddr_in *from, benc_t *msg) {
+    benc_t *t = benc_dict_get(msg, "t");
+    benc_t *q = benc_dict_get(msg, "q");
+    benc_t *a = benc_dict_get(msg, "a");
+    if (!t || t->t != BENC_STR || t->slen != 2 || !q || q->t != BENC_STR) return;
+
+    // record node if possible
+    if (a && a->t == BENC_DICT) {
+        benc_t *id = benc_dict_get(a, "id");
+        if (id && id->t == BENC_STR && id->slen == 20) {
+            pthread_mutex_lock(&st->mu);
+            add_node_locked(st, id->s, from);
+            pthread_mutex_unlock(&st->mu);
+        }
+    }
+
+    char qname[32] = {0};
+    size_t qn = q->slen < sizeof(qname)-1 ? q->slen : sizeof(qname)-1;
+    memcpy(qname, q->s, qn);
+
+    if (strcmp(qname, "ping") == 0) {
+        benc_t *r = benc_new_dict();
+        benc_t *resp = krpc_build_resp(st, t->s, r);
+        send_krpc(st, from, resp);
+        benc_free(resp);
+        return;
+    }
+
+    if (strcmp(qname, "find_node") == 0 || strcmp(qname, "get_peers") == 0) {
+        benc_t *r = benc_new_dict();
+        uint8_t *nodes=NULL; size_t nodes_len=0;
+        pthread_mutex_lock(&st->mu);
+        compact_nodes_locked(st, &nodes, &nodes_len);
+        pthread_mutex_unlock(&st->mu);
+        if (nodes) {
+            benc_dict_set(r, "nodes", benc_new_str(nodes, nodes_len));
+            free(nodes);
+        }
+
+        if (strcmp(qname, "get_peers") == 0) {
+            benc_t *ih = a ? benc_dict_get(a, "info_hash") : NULL;
+            if (ih && ih->t == BENC_STR && ih->slen == 20) {
+                uint8_t tok[4];
+                token_for_ip(st->secret, from, tok);
+                benc_dict_set(r, "token", benc_new_str(tok, 4));
+
+                // if we have peers, include values
+                pthread_mutex_lock(&st->mu);
+                uint8_t *vals=NULL; size_t vlen=0;
+                int ok = peers_get_locked(st, ih->s, &vals, &vlen);
+                pthread_mutex_unlock(&st->mu);
+                if (ok == 0 && vlen >= 6) {
+                    benc_t *lst = benc_new_list();
+                    for (size_t i=0;i+6<=vlen;i+=6) {
+                        benc_list_add(lst, benc_new_str(vals+i, 6));
+                    }
+                    benc_dict_set(r, "values", lst);
+                    free(vals);
+                }
+            }
+        }
+
+        benc_t *resp = krpc_build_resp(st, t->s, r);
+        send_krpc(st, from, resp);
+        benc_free(resp);
+        return;
+    }
+
+    if (strcmp(qname, "announce_peer") == 0) {
+        benc_t *ih = a ? benc_dict_get(a, "info_hash") : NULL;
+        benc_t *port = a ? benc_dict_get(a, "port") : NULL;
+        benc_t *tok = a ? benc_dict_get(a, "token") : NULL;
+        if (ih && ih->t == BENC_STR && ih->slen == 20 && port && port->t == BENC_INT && tok && tok->t == BENC_STR && tok->slen == 4) {
+            uint8_t exp[4];
+            token_for_ip(st->secret, from, exp);
+            if (memcmp(exp, tok->s, 4) == 0) {
+                // add announcing peer address
+                uint16_t p = (uint16_t)port->i;
+                uint8_t comp[6];
+                memcpy(comp, &from->sin_addr, 4);
+                uint16_t np = htons(p);
+                memcpy(comp+4, &np, 2);
+                pthread_mutex_lock(&st->mu);
+                peers_add_locked(st, ih->s, comp);
+                pthread_mutex_unlock(&st->mu);
+            }
+        }
+        benc_t *resp = krpc_build_resp(st, t->s, benc_new_dict());
+        send_krpc(st, from, resp);
+        benc_free(resp);
+        return;
+    }
+
+    // unknown query
+    benc_t *resp = krpc_build_resp(st, t->s, benc_new_dict());
+    send_krpc(st, from, resp);
+    benc_free(resp);
+}
+
+static void handle_response(dht_state_t *st, benc_t *msg) {
+    benc_t *t = benc_dict_get(msg, "t");
+    if (!t || t->t != BENC_STR || t->slen != 2) return;
+    uint16_t tx = (uint16_t)((t->s[0] << 8) | t->s[1]);
+
+    pthread_mutex_lock(&st->mu);
+    pending_t *p = pending_find_locked(st, tx);
+    if (p) {
+        p->resp = msg;
+        p->done = 1;
+        pthread_cond_broadcast(&p->cv);
+        pthread_mutex_unlock(&st->mu);
+        return;
+    }
+    pthread_mutex_unlock(&st->mu);
+    // no pending; free
+    benc_free(msg);
+}
+
+static void *dht_thread(void *arg) {
+    dht_state_t *st = (dht_state_t*)arg;
+    uint8_t buf[4096];
+
+    while (1) {
+        struct sockaddr_in from; socklen_t fl = sizeof(from);
+        ssize_t n = recvfrom(st->udp_fd, buf, sizeof(buf), 0, (struct sockaddr*)&from, &fl);
+        if (n <= 0) continue;
+
+        benc_t *msg = NULL; size_t used=0;
+        if (benc_parse(buf, (size_t)n, &msg, &used) != 0 || !msg || msg->t != BENC_DICT) {
+            benc_free(msg);
+            continue;
+        }
+        benc_t *y = benc_dict_get(msg, "y");
+        if (!y || y->t != BENC_STR || y->slen < 1) { benc_free(msg); continue; }
+        if (y->slen == 1 && y->s[0] == 'q') {
+            handle_query(st, &from, msg);
+            benc_free(msg);
+        } else if (y->slen == 1 && y->s[0] == 'r') {
+            // response is handed to pending (takes ownership)
+            handle_response(st, msg);
+        } else {
+            benc_free(msg);
+        }
+    }
+    return NULL;
+}
+
+static int load_bootstrap_from_db(dht_state_t *st) {
+    const char *sql = "SELECT host, port, pubkey FROM contacts WHERE is_relay=1 AND host!='' AND port>0 LIMIT 200;";
+    sqlite3_stmt *q = NULL;
+    if (sqlite3_prepare_v2(st->db->db, sql, -1, &q, NULL) != SQLITE_OK) return -1;
+
+    while (sqlite3_step(q) == SQLITE_ROW) {
+        const char *host = (const char*)sqlite3_column_text(q, 0);
+        int port = sqlite3_column_int(q, 1);
+        const void *pk = sqlite3_column_blob(q, 2);
+        int pklen = sqlite3_column_bytes(q, 2);
+        if (!host || port <= 0 || port > 65535 || pklen != 32) continue;
+        struct sockaddr_in a; memset(&a, 0, sizeof(a));
+        a.sin_family = AF_INET;
+        a.sin_port = htons((uint16_t)port);
+        if (inet_pton(AF_INET, host, &a.sin_addr) != 1) continue;
+        uint8_t nid[20];
+        sha1_bytes((const uint8_t*)pk, 32, nid);
+        pthread_mutex_lock(&st->mu);
+        add_node_locked(st, nid, &a);
+        pthread_mutex_unlock(&st->mu);
+    }
+
+    sqlite3_finalize(q);
+    return 0;
+}
+
+static int krpc_query_one(dht_state_t *st, const struct sockaddr_in *to, benc_t *query, benc_t **resp_out) {
+    *resp_out = NULL;
+    benc_t *t = benc_dict_get(query, "t");
+    if (!t || t->t != BENC_STR || t->slen != 2) return -1;
+    uint16_t tx = (uint16_t)((t->s[0] << 8) | t->s[1]);
+
+    pthread_mutex_lock(&st->mu);
+    pending_t *p = pending_alloc_locked(st, tx);
+    pthread_mutex_unlock(&st->mu);
+    if (!p) return -1;
+
+    if (send_krpc(st, to, query) != 0) {
+        pthread_mutex_lock(&st->mu);
+        pending_free_locked(p);
+        pthread_mutex_unlock(&st->mu);
+        return -1;
+    }
+
+    // wait up to 900ms
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_nsec += 900 * 1000 * 1000;
+    if (ts.tv_nsec >= 1000000000L) { ts.tv_sec += 1; ts.tv_nsec -= 1000000000L; }
+
+    pthread_mutex_lock(&st->mu);
+    while (!p->done) {
+        if (pthread_cond_timedwait(&p->cv, &st->mu, &ts) == ETIMEDOUT) break;
+    }
+    if (p->done && p->resp) {
+        *resp_out = p->resp;
+        p->resp = NULL;
+    }
+    pending_free_locked(p);
+    pthread_mutex_unlock(&st->mu);
+
+    return (*resp_out) ? 0 : -1;
+}
+
+static void parse_nodes_into_state(dht_state_t *st, const uint8_t *nodes, size_t nodes_len) {
+    if (!nodes || nodes_len % 26 != 0) return;
+    for (size_t i=0;i+26<=nodes_len;i+=26) {
+        uint8_t nid[20];
+        memcpy(nid, nodes+i, 20);
+        struct sockaddr_in a; memset(&a, 0, sizeof(a));
+        a.sin_family = AF_INET;
+        memcpy(&a.sin_addr, nodes+i+20, 4);
+        memcpy(&a.sin_port, nodes+i+24, 2);
+        pthread_mutex_lock(&st->mu);
+        add_node_locked(st, nid, &a);
+        pthread_mutex_unlock(&st->mu);
+    }
+}
+
+int pcomm_dht_get_peers_hosts(const uint8_t infohash20[20],
+                             char (*hosts)[64], uint16_t *ports,
+                             size_t cap, size_t *out_len) {
+    if (!g_dht || !hosts || !ports || !out_len) return -1;
+    *out_len = 0;
+
+    // Seed worklist from known nodes
+    struct sockaddr_in work[128];
+    size_t wlen = 0;
+    pthread_mutex_lock(&g_dht->mu);
+    size_t take = g_dht->nodes_len < DHT_QUERY_FANOUT ? g_dht->nodes_len : DHT_QUERY_FANOUT;
+    for (size_t i=0;i<take;i++) work[wlen++] = g_dht->nodes[i].addr;
+    pthread_mutex_unlock(&g_dht->mu);
+
+    size_t queried = 0;
+    for (size_t wi=0; wi<wlen && queried < 64 && *out_len < cap; wi++, queried++) {
+        uint16_t tx = rand_tx();
+        benc_t *a = benc_new_dict();
+        benc_dict_set(a, "info_hash", benc_new_str(infohash20, 20));
+        benc_t *q = krpc_build_query(g_dht, tx, "get_peers", a);
+        if (!q) continue;
+
+        benc_t *resp = NULL;
+        if (krpc_query_one(g_dht, &work[wi], q, &resp) == 0 && resp) {
+            benc_t *r = benc_dict_get(resp, "r");
+            if (r && r->t == BENC_DICT) {
+                benc_t *vals = benc_dict_get(r, "values");
+                if (vals && vals->t == BENC_LIST) {
+                    for (size_t i=0;i<vals->list_len && *out_len < cap;i++) {
+                        benc_t *s = vals->list[i];
+                        if (!s || s->t != BENC_STR || s->slen != 6) continue;
+                        struct in_addr ip; memcpy(&ip, s->s, 4);
+                        uint16_t p; memcpy(&p, s->s+4, 2); p = ntohs(p);
+                        const char *ipstr = inet_ntoa(ip);
+                        snprintf(hosts[*out_len], 64, "%s", ipstr);
+                        ports[*out_len] = p;
+                        (*out_len)++;
+                    }
+                }
+                benc_t *nodes = benc_dict_get(r, "nodes");
+                if (nodes && nodes->t == BENC_STR && nodes->slen >= 26) {
+                    parse_nodes_into_state(g_dht, nodes->s, nodes->slen);
+                    // also add a few to worklist (depth 2)
+                    if (wlen < 128) {
+                        size_t can = (128 - wlen);
+                        size_t add = nodes->slen / 26;
+                        if (add > can) add = can;
+                        for (size_t i=0;i<add;i++) {
+                            struct sockaddr_in a2; memset(&a2,0,sizeof(a2));
+                            a2.sin_family = AF_INET;
+                            memcpy(&a2.sin_addr, nodes->s + i*26 + 20, 4);
+                            memcpy(&a2.sin_port, nodes->s + i*26 + 24, 2);
+                            work[wlen++] = a2;
+                        }
+                    }
+                }
+            }
+            benc_free(resp);
+        }
+        benc_free(q);
+    }
+
+    return (*out_len > 0) ? 0 : -1;
+}
+
+int pcomm_dht_announce(const uint8_t infohash20[20], uint16_t port) {
+    if (!g_dht) return -1;
+
+    // For each known node: get_peers to obtain token, then announce_peer.
+    struct sockaddr_in nodes[DHT_QUERY_FANOUT];
+    size_t nlen = 0;
+    pthread_mutex_lock(&g_dht->mu);
+    size_t take = g_dht->nodes_len < DHT_QUERY_FANOUT ? g_dht->nodes_len : DHT_QUERY_FANOUT;
+    for (size_t i=0;i<take;i++) nodes[nlen++] = g_dht->nodes[i].addr;
+    pthread_mutex_unlock(&g_dht->mu);
+
+    for (size_t i=0;i<nlen;i++) {
+        uint16_t tx = rand_tx();
+        benc_t *a = benc_new_dict();
+        benc_dict_set(a, "info_hash", benc_new_str(infohash20, 20));
+        benc_t *q = krpc_build_query(g_dht, tx, "get_peers", a);
+        if (!q) continue;
+
+        benc_t *resp = NULL;
+        uint8_t tok[4]; memset(tok,0,4);
+        if (krpc_query_one(g_dht, &nodes[i], q, &resp) == 0 && resp) {
+            benc_t *r = benc_dict_get(resp, "r");
+            if (r && r->t == BENC_DICT) {
+                benc_t *tkn = benc_dict_get(r, "token");
+                if (tkn && tkn->t == BENC_STR && tkn->slen == 4) memcpy(tok, tkn->s, 4);
+                benc_t *nds = benc_dict_get(r, "nodes");
+                if (nds && nds->t == BENC_STR && nds->slen >= 26) parse_nodes_into_state(g_dht, nds->s, nds->slen);
+            }
+            benc_free(resp);
+        }
+        benc_free(q);
+
+        if (tok[0] == 0 && tok[1] == 0 && tok[2] == 0 && tok[3] == 0) continue;
+
+        uint16_t tx2 = rand_tx();
+        benc_t *a2 = benc_new_dict();
+        benc_dict_set(a2, "info_hash", benc_new_str(infohash20, 20));
+        benc_dict_set(a2, "port", benc_new_int(port));
+        benc_dict_set(a2, "token", benc_new_str(tok, 4));
+        benc_t *q2 = krpc_build_query(g_dht, tx2, "announce_peer", a2);
+        if (!q2) continue;
+        benc_t *resp2=NULL;
+        krpc_query_one(g_dht, &nodes[i], q2, &resp2);
+        benc_free(resp2);
+        benc_free(q2);
+    }
+
+    return 0;
+}
+
+int pcomm_dht_start(const pcomm_config_t *cfg, const pcomm_identity_t *me, pcomm_db_t *db) {
+    if (!cfg || !me || !db) return -1;
+    if (g_dht) return 0;
+
+    dht_state_t *st = (dht_state_t*)calloc(1, sizeof(dht_state_t));
+    if (!st) return -1;
+    pthread_mutex_init(&st->mu, NULL);
+    st->db = db;
+    st->listen_port = cfg->relay_port;
+
+    compute_node_id(me, st->node_id);
+    pcomm_random(st->secret, sizeof(st->secret));
+
+    st->udp_fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (st->udp_fd < 0) { free(st); return -1; }
+
+    int yes = 1;
+    setsockopt(st->udp_fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+
+    struct sockaddr_in a; memset(&a,0,sizeof(a));
+    a.sin_family = AF_INET;
+    a.sin_addr.s_addr = htonl(INADDR_ANY);
+    a.sin_port = htons(cfg->relay_port);
+    if (bind(st->udp_fd, (struct sockaddr*)&a, sizeof(a)) != 0) {
+        close(st->udp_fd);
+        free(st);
+        return -1;
+    }
+
+    // bootstrap from DB
+    load_bootstrap_from_db(st);
+
+    if (pthread_create(&st->th, NULL, dht_thread, st) != 0) {
+        close(st->udp_fd);
+        free(st);
+        return -1;
+    }
+
+    g_dht = st;
+    fprintf(stderr, "[dht] started on UDP %u\n", (unsigned)cfg->relay_port);
+    return 0;
+}

--- a/src/dht.h
+++ b/src/dht.h
@@ -1,0 +1,25 @@
+#ifndef PCOMM_DHT_H
+#define PCOMM_DHT_H
+
+#include "pcomm.h"
+#include "db.h"
+#include <stdint.h>
+#include <stddef.h>
+
+// Start a minimal BEP-5 DHT node on UDP port = cfg->relay_port.
+// The DHT routing table is bootstrapped from the relay contacts database and peers.txt.
+int pcomm_dht_start(const pcomm_config_t *cfg, const pcomm_identity_t *me, pcomm_db_t *db);
+
+// Compute infohashes used by PComm for descriptor/mailbox discovery.
+void pcomm_dht_infohash_desc(const char *user_id, uint8_t out20[20]);
+void pcomm_dht_infohash_mb(const char *user_id, uint8_t out20[20]);
+
+// Announce ourselves for the given infohash (announce_peer). Port is the TCP relay port.
+int pcomm_dht_announce(const uint8_t infohash20[20], uint16_t port);
+
+// Lookup peers for the given infohash. Returns (host,port) pairs (IPv4 only).
+int pcomm_dht_get_peers_hosts(const uint8_t infohash20[20],
+                             char (*hosts)[64], uint16_t *ports,
+                             size_t cap, size_t *out_len);
+
+#endif

--- a/src/hidden.c
+++ b/src/hidden.c
@@ -1,0 +1,859 @@
+#define _GNU_SOURCE
+#include "hidden.h"
+#include "net.h"
+#include "proto.h"
+#include "onion.h"
+#include "crypto.h"
+#include "identity.h"
+#include "msg.h"
+#include "dht.h"
+#include "circuit.h"
+
+#include <pthread.h>
+#include <sqlite3.h>
+#include <openssl/sha.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+
+static void put_u16(uint8_t *p, uint16_t v){ uint16_t n=htons(v); memcpy(p,&n,2); }
+static void put_u32(uint8_t *p, uint32_t v){ uint32_t n=htonl(v); memcpy(p,&n,4); }
+static uint16_t get_u16(const uint8_t *p){ uint16_t n; memcpy(&n,p,2); return ntohs(n); }
+static uint32_t get_u32(const uint8_t *p){ uint32_t n; memcpy(&n,p,4); return ntohl(n); }
+
+static uint32_t epoch_now(void) {
+    // 6-hour epochs
+    time_t t = time(NULL);
+    return (uint32_t)(t / (6 * 3600));
+}
+
+static void sha256_key(const char *tag, const char *user_id, uint32_t epoch, uint8_t out[32]) {
+    SHA256_CTX ctx;
+    SHA256_Init(&ctx);
+    SHA256_Update(&ctx, tag, strlen(tag));
+    uint8_t z = 0;
+    SHA256_Update(&ctx, &z, 1);
+    SHA256_Update(&ctx, user_id, strlen(user_id));
+    SHA256_Update(&ctx, &z, 1);
+    uint32_t e = htonl(epoch);
+    SHA256_Update(&ctx, &e, sizeof(e));
+    SHA256_Final(out, &ctx);
+}
+
+typedef struct {
+    pcomm_config_t cfg;
+    pcomm_identity_t me;
+    pcomm_db_t *db;
+
+    // cached intro points from last publish
+    pcomm_peer_t intros[3];
+    size_t intro_count;
+
+    pthread_mutex_t lock;
+} hidden_state_t;
+
+static hidden_state_t *g_hidden = NULL;
+
+// Load a random onion path (0..3 relays) excluding specific IDs.
+static int load_onion_relays(pcomm_db_t *db, const char *ex1, const char *ex2, const char *ex3, pcomm_peer_t *out, size_t out_cap, size_t *out_len) {
+    *out_len = 0;
+    const char *sql =
+        "SELECT user_id, host, port, pubkey FROM contacts "
+        "WHERE is_relay=1 AND host!='' AND port>0 "
+        "AND user_id != ? AND user_id != ? AND user_id != ? "
+        "ORDER BY RANDOM() LIMIT ?;";
+
+    sqlite3_stmt *st = NULL;
+    if (sqlite3_prepare_v2(db->db, sql, -1, &st, NULL) != SQLITE_OK) return -1;
+    sqlite3_bind_text(st, 1, ex1 ? ex1 : "", -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(st, 2, ex2 ? ex2 : "", -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(st, 3, ex3 ? ex3 : "", -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(st, 4, (int)out_cap);
+
+    while (sqlite3_step(st) == SQLITE_ROW) {
+        const char *uid = (const char*)sqlite3_column_text(st, 0);
+        const char *host = (const char*)sqlite3_column_text(st, 1);
+        int port = sqlite3_column_int(st, 2);
+        const void *pk = sqlite3_column_blob(st, 3);
+        int pklen = sqlite3_column_bytes(st, 3);
+        if (!uid || !host || pklen != 32 || port <= 0 || port > 65535) continue;
+        pcomm_peer_t *p = &out[*out_len];
+        memset(p, 0, sizeof(*p));
+        snprintf(p->user_id, sizeof(p->user_id), "%s", uid);
+        snprintf(p->host, sizeof(p->host), "%s", host);
+        p->port = (uint16_t)port;
+        memcpy(p->pubkey, pk, 32);
+        (*out_len)++;
+        if (*out_len >= out_cap) break;
+    }
+    sqlite3_finalize(st);
+    return 0;
+}
+
+// List all known relays (cap limited)
+static int list_all_relays(pcomm_db_t *db, pcomm_peer_t **out, size_t *out_len) {
+    *out = NULL; *out_len = 0;
+    const char *sql = "SELECT user_id, host, port, pubkey FROM contacts WHERE is_relay=1 AND host!='' AND port>0 LIMIT 500;";
+    sqlite3_stmt *st = NULL;
+    if (sqlite3_prepare_v2(db->db, sql, -1, &st, NULL) != SQLITE_OK) return -1;
+
+    size_t cap = 64;
+    pcomm_peer_t *arr = (pcomm_peer_t*)calloc(cap, sizeof(pcomm_peer_t));
+    if (!arr) { sqlite3_finalize(st); return -1; }
+
+    size_t n = 0;
+    while (sqlite3_step(st) == SQLITE_ROW) {
+        const char *uid = (const char*)sqlite3_column_text(st, 0);
+        const char *host = (const char*)sqlite3_column_text(st, 1);
+        int port = sqlite3_column_int(st, 2);
+        const void *pk = sqlite3_column_blob(st, 3);
+        int pklen = sqlite3_column_bytes(st, 3);
+        if (!uid || !host || pklen != 32 || port <= 0 || port > 65535) continue;
+        if (n >= cap) {
+            cap *= 2;
+            pcomm_peer_t *tmp = (pcomm_peer_t*)realloc(arr, cap * sizeof(pcomm_peer_t));
+            if (!tmp) break;
+            arr = tmp;
+        }
+        memset(&arr[n], 0, sizeof(pcomm_peer_t));
+        snprintf(arr[n].user_id, sizeof(arr[n].user_id), "%s", uid);
+        snprintf(arr[n].host, sizeof(arr[n].host), "%s", host);
+        arr[n].port = (uint16_t)port;
+        memcpy(arr[n].pubkey, pk, 32);
+        n++;
+    }
+    sqlite3_finalize(st);
+
+    *out = arr;
+    *out_len = n;
+    return (n > 0) ? 0 : -1;
+}
+
+typedef struct {
+    pcomm_peer_t p;
+    uint8_t h[32];
+} peer_hash_t;
+
+static int cmp_peerhash(const void *a, const void *b) {
+    const peer_hash_t *pa = (const peer_hash_t*)a;
+    const peer_hash_t *pb = (const peer_hash_t*)b;
+    return memcmp(pa->h, pb->h, 32);
+}
+
+static int select_hsdirs(pcomm_db_t *db, const char *target_user_id, uint32_t epoch, pcomm_peer_t out[3], size_t *out_len) {
+    *out_len = 0;
+
+    pcomm_peer_t *relays = NULL;
+    size_t nrel = 0;
+    if (list_all_relays(db, &relays, &nrel) != 0 || nrel == 0) {
+        free(relays);
+        return -1;
+    }
+
+    peer_hash_t *ph = (peer_hash_t*)calloc(nrel, sizeof(peer_hash_t));
+    if (!ph) { free(relays); return -1; }
+    for (size_t i = 0; i < nrel; i++) {
+        ph[i].p = relays[i];
+        SHA256((const unsigned char*)relays[i].user_id, strlen(relays[i].user_id), ph[i].h);
+    }
+    qsort(ph, nrel, sizeof(peer_hash_t), cmp_peerhash);
+
+    uint8_t seed[32];
+    sha256_key("pcomm-hsdir", target_user_id, epoch, seed);
+    uint64_t idx = 0;
+    for (int i = 0; i < 8; i++) idx = (idx << 8) | seed[i];
+    idx = (nrel > 0) ? (idx % nrel) : 0;
+
+    size_t want = (nrel >= 3) ? 3 : nrel;
+    for (size_t k = 0; k < want; k++) {
+        out[k] = ph[(idx + k) % nrel].p;
+        (*out_len)++;
+    }
+
+    free(ph);
+    free(relays);
+    return (*out_len > 0) ? 0 : -1;
+}
+
+static int onion_send_ctrl(pcomm_db_t *db, const pcomm_config_t *cfg, const pcomm_identity_t *me,
+                           const pcomm_peer_t *dest,
+                           const uint8_t *ctrl_payload, uint32_t ctrl_len,
+                           int roundtrip,
+                           uint8_t **resp_payload, uint32_t *resp_len) {
+    if (resp_payload) *resp_payload = NULL;
+    if (resp_len) *resp_len = 0;
+
+    // Prefer long-lived circuit + stream multiplexing when available.
+    pcomm_circuit_t *c = pcomm_circuit_get();
+    if (c && dest && dest->host[0] && dest->port) {
+        pcomm_msg_type_t rt = 0; uint8_t *rp = NULL; uint32_t rpl = 0;
+        int rc = pcomm_circuit_rpc(c, dest->host, dest->port, PCOMM_MSG_CTRL,
+                                   ctrl_payload, ctrl_len, roundtrip,
+                                   &rt, &rp, &rpl);
+        if (rc == 0) {
+            if (roundtrip) {
+                if (rt != PCOMM_MSG_CTRL) { free(rp); return -1; }
+                if (resp_payload) *resp_payload = rp; else free(rp);
+                if (resp_len) *resp_len = rpl;
+            }
+            return 0;
+        }
+        free(rp);
+        // fall back to single-shot onions if circuit fails
+    }
+
+    // Build a random onion path (up to 3 relays), excluding self and dest.
+    pcomm_peer_t path[3];
+    size_t path_len = 0;
+    load_onion_relays(db, me->user_id, dest->user_id, NULL, path, 3, &path_len);
+
+    if (path_len == 0) {
+        // direct
+        int fd = net_connect_tcp(dest->host, dest->port);
+        if (fd < 0) return -1;
+        int rc = pcomm_send_packet(fd, PCOMM_MSG_CTRL, NULL, ctrl_payload, ctrl_len);
+        if (rc != 0) { close(fd); return -1; }
+        if (roundtrip) {
+            pcomm_msg_type_t rtype; uint8_t eph[32]; uint8_t *rp=NULL; uint32_t rpl=0;
+            if (pcomm_recv_packet(fd, &rtype, eph, &rp, &rpl) == 0 && rtype == PCOMM_MSG_CTRL) {
+                if (resp_payload) *resp_payload = rp; else free(rp);
+                if (resp_len) *resp_len = rpl;
+                close(fd);
+                return 0;
+            }
+            free(rp);
+            close(fd);
+            return -1;
+        }
+        close(fd);
+        return 0;
+    }
+
+    // Onion deliver to dest with CTRL
+    uint8_t eph_pub[32];
+    uint8_t *onion = NULL; uint32_t onion_len = 0;
+    if (pcomm_onion_build_v1(path, path_len, dest->host, dest->port, PCOMM_MSG_CTRL,
+                             ctrl_payload, ctrl_len, roundtrip, eph_pub, &onion, &onion_len) != 0) {
+        free(onion);
+        return -1;
+    }
+
+    int fd = net_connect_tcp(path[0].host, path[0].port);
+    if (fd < 0) { free(onion); return -1; }
+    int rc = pcomm_send_packet(fd, PCOMM_MSG_ONION, eph_pub, onion, onion_len);
+    free(onion);
+    if (rc != 0) { close(fd); return -1; }
+
+    if (!roundtrip) {
+        close(fd);
+        return 0;
+    }
+
+    pcomm_msg_type_t rtype; uint8_t eph[32]; uint8_t *rp=NULL; uint32_t rpl=0;
+    if (pcomm_recv_packet(fd, &rtype, eph, &rp, &rpl) == 0 && rtype == PCOMM_MSG_CTRL) {
+        if (resp_payload) *resp_payload = rp; else free(rp);
+        if (resp_len) *resp_len = rpl;
+        close(fd);
+        return 0;
+    }
+    free(rp);
+    close(fd);
+    return -1;
+}
+
+static int ctrl_build_desc_get(const uint8_t infohash[20], const uint8_t dkey[32], uint8_t **out, uint32_t *out_len) {
+    uint32_t len = 1 + 20 + 32;
+    uint8_t *b = (uint8_t*)malloc(len);
+    if (!b) return -1;
+    uint32_t off = 0;
+    b[off++] = (uint8_t)PCOMM_CTRL_DESC_GET;
+    memcpy(b + off, infohash, 20); off += 20;
+    memcpy(b + off, dkey, 32); off += 32;
+    *out = b; *out_len = len;
+    return 0;
+}
+
+static int ctrl_build_desc_put(const uint8_t infohash[20], const uint8_t dkey[32], uint32_t expires_unix, const uint8_t *blob, uint32_t blob_len,
+                              uint8_t **out, uint32_t *out_len) {
+    uint32_t len = 1 + 20 + 32 + 4 + 4 + blob_len;
+    uint8_t *b = (uint8_t*)malloc(len);
+    if (!b) return -1;
+    uint32_t off = 0;
+    b[off++] = (uint8_t)PCOMM_CTRL_DESC_PUT;
+    memcpy(b + off, infohash, 20); off += 20;
+    memcpy(b + off, dkey, 32); off += 32;
+    put_u32(b + off, expires_unix); off += 4;
+    put_u32(b + off, blob_len); off += 4;
+    memcpy(b + off, blob, blob_len); off += blob_len;
+    if (off != len) { free(b); return -1; }
+    *out = b; *out_len = len;
+    return 0;
+}
+
+static int ctrl_build_mb_put(const uint8_t infohash[20], const uint8_t mkey[32], const uint8_t *blob, uint32_t blob_len, uint8_t **out, uint32_t *out_len) {
+    uint32_t len = 1 + 20 + 32 + 4 + blob_len;
+    uint8_t *b = (uint8_t*)malloc(len);
+    if (!b) return -1;
+    uint32_t off = 0;
+    b[off++] = (uint8_t)PCOMM_CTRL_MB_PUT;
+    memcpy(b + off, infohash, 20); off += 20;
+    memcpy(b + off, mkey, 32); off += 32;
+    put_u32(b + off, blob_len); off += 4;
+    memcpy(b + off, blob, blob_len); off += blob_len;
+    if (off != len) { free(b); return -1; }
+    *out = b; *out_len = len;
+    return 0;
+}
+
+static int ctrl_build_mb_get(const uint8_t infohash[20], const uint8_t mkey[32], uint8_t **out, uint32_t *out_len) {
+    uint32_t len = 1 + 20 + 32;
+    uint8_t *b = (uint8_t*)malloc(len);
+    if (!b) return -1;
+    uint32_t off = 0;
+    b[off++] = (uint8_t)PCOMM_CTRL_MB_GET;
+    memcpy(b + off, infohash, 20); off += 20;
+    memcpy(b + off, mkey, 32); off += 32;
+    *out = b; *out_len = len;
+    return 0;
+}
+
+static int ctrl_build_noop(uint8_t **out, uint32_t *out_len) {
+    uint8_t *b = (uint8_t*)malloc(1);
+    if (!b) return -1;
+    b[0] = (uint8_t)PCOMM_CTRL_NOOP;
+    *out = b; *out_len = 1;
+    return 0;
+}
+
+static int parse_desc_resp(const uint8_t *payload, uint32_t payload_len, uint8_t **blob_out, uint32_t *blob_len_out) {
+    *blob_out = NULL; *blob_len_out = 0;
+    if (!payload || payload_len < 1 + 1 + 4) return -1;
+    uint32_t off = 0;
+    if (payload[off++] != (uint8_t)PCOMM_CTRL_DESC_RESP) return -1;
+    uint8_t ok = payload[off++];
+    uint32_t bl = get_u32(payload + off); off += 4;
+    if (!ok || payload_len < off + bl) return -1;
+    uint8_t *b = (uint8_t*)malloc(bl);
+    if (!b) return -1;
+    memcpy(b, payload + off, bl);
+    *blob_out = b; *blob_len_out = bl;
+    return 0;
+}
+
+static int parse_descriptor_blob(const uint8_t *blob, uint32_t blob_len, pcomm_peer_t *intros, size_t intros_cap, size_t *intros_len) {
+    *intros_len = 0;
+    if (!blob || blob_len < 1 + 4 + 1) return -1;
+    uint32_t off = 0;
+    uint8_t ver = blob[off++];
+    if (ver != 1) return -1;
+    (void)get_u32(blob + off); off += 4; // epoch
+    uint8_t cnt = blob[off++];
+    if (cnt > intros_cap) cnt = (uint8_t)intros_cap;
+
+    for (uint8_t i = 0; i < cnt; i++) {
+        if (blob_len < off + 2) break;
+        uint16_t uid_len = get_u16(blob + off); off += 2;
+        if (uid_len == 0 || uid_len > 95 || blob_len < off + uid_len) break;
+        char uid[96];
+        memcpy(uid, blob + off, uid_len); uid[uid_len] = '\0';
+        off += uid_len;
+
+        if (blob_len < off + 1) break;
+        uint8_t hlen = blob[off++];
+        if (hlen == 0 || hlen > 63 || blob_len < off + hlen + 2 + 32) break;
+        char host[64];
+        memcpy(host, blob + off, hlen); host[hlen] = '\0';
+        off += hlen;
+        uint16_t port = get_u16(blob + off); off += 2;
+        uint8_t pk[32];
+        memcpy(pk, blob + off, 32); off += 32;
+
+        pcomm_peer_t *p = &intros[*intros_len];
+        memset(p, 0, sizeof(*p));
+        snprintf(p->user_id, sizeof(p->user_id), "%s", uid);
+        snprintf(p->host, sizeof(p->host), "%s", host);
+        p->port = port;
+        memcpy(p->pubkey, pk, 32);
+        (*intros_len)++;
+    }
+    return (*intros_len > 0) ? 0 : -1;
+}
+
+static int build_descriptor_blob(uint32_t epoch, const pcomm_peer_t *intros, size_t intro_count, uint8_t **out, uint32_t *out_len) {
+    if (!out || !out_len) return -1;
+    if (intro_count > 3) intro_count = 3;
+
+    uint32_t len = 1 + 4 + 1;
+    for (size_t i = 0; i < intro_count; i++) {
+        size_t uid_len = strlen(intros[i].user_id);
+        size_t host_len = strlen(intros[i].host);
+        len += 2 + (uint32_t)uid_len + 1 + (uint32_t)host_len + 2 + 32;
+    }
+
+    uint8_t *b = (uint8_t*)malloc(len);
+    if (!b) return -1;
+    uint32_t off = 0;
+    b[off++] = 1;
+    put_u32(b + off, epoch); off += 4;
+    b[off++] = (uint8_t)intro_count;
+    for (size_t i = 0; i < intro_count; i++) {
+        uint16_t uid_len = (uint16_t)strlen(intros[i].user_id);
+        uint8_t host_len = (uint8_t)strlen(intros[i].host);
+        put_u16(b + off, uid_len); off += 2;
+        memcpy(b + off, intros[i].user_id, uid_len); off += uid_len;
+        b[off++] = host_len;
+        memcpy(b + off, intros[i].host, host_len); off += host_len;
+        put_u16(b + off, intros[i].port); off += 2;
+        memcpy(b + off, intros[i].pubkey, 32); off += 32;
+    }
+    if (off != len) { free(b); return -1; }
+    *out = b; *out_len = len;
+    return 0;
+}
+
+static int fetch_descriptor(pcomm_db_t *db, const pcomm_config_t *cfg, const pcomm_identity_t *me,
+                            const char *target_id, uint32_t epoch, pcomm_peer_t *intros, size_t intros_cap, size_t *intros_len) {
+    *intros_len = 0;
+    uint8_t dkey[32];
+    sha256_key("pcomm-desc-v1", target_id, epoch, dkey);
+
+    uint8_t infohash[20];
+    pcomm_dht_infohash_desc(target_id, infohash);
+
+    // Prefer DHT-discovered descriptor hosts
+    char hosts[8][64]; uint16_t ports[8]; size_t hn = 0;
+    if (pcomm_dht_get_peers_hosts(infohash, hosts, ports, 8, &hn) == 0 && hn > 0) {
+        for (size_t i = 0; i < hn; i++) {
+            pcomm_peer_t dest; memset(&dest, 0, sizeof(dest));
+            snprintf(dest.host, sizeof(dest.host), "%s", hosts[i]);
+            dest.port = ports[i];
+
+            uint8_t *req = NULL; uint32_t req_len = 0;
+            if (ctrl_build_desc_get(infohash, dkey, &req, &req_len) != 0) continue;
+
+            uint8_t *resp = NULL; uint32_t resp_len = 0;
+            int rc = onion_send_ctrl(db, cfg, me, &dest, req, req_len, 1, &resp, &resp_len);
+            free(req);
+            if (rc != 0 || !resp) { free(resp); continue; }
+
+            uint8_t *blob = NULL; uint32_t blob_len = 0;
+            if (parse_desc_resp(resp, resp_len, &blob, &blob_len) == 0) {
+                if (parse_descriptor_blob(blob, blob_len, intros, intros_cap, intros_len) == 0) {
+                    free(blob);
+                    free(resp);
+                    return 0;
+                }
+                free(blob);
+            }
+            free(resp);
+        }
+    }
+
+    // Fallback: deterministic HSDirs (v2 behavior)
+    pcomm_peer_t hs[3]; size_t hs_len = 0;
+    if (select_hsdirs(db, target_id, epoch, hs, &hs_len) != 0) return -1;
+    for (size_t i = 0; i < hs_len; i++) {
+        uint8_t *req = NULL; uint32_t req_len = 0;
+        if (ctrl_build_desc_get(infohash, dkey, &req, &req_len) != 0) continue;
+        uint8_t *resp = NULL; uint32_t resp_len = 0;
+        int rc = onion_send_ctrl(db, cfg, me, &hs[i], req, req_len, 1, &resp, &resp_len);
+        free(req);
+        if (rc != 0 || !resp) { free(resp); continue; }
+        uint8_t *blob = NULL; uint32_t blob_len = 0;
+        if (parse_desc_resp(resp, resp_len, &blob, &blob_len) == 0) {
+            if (parse_descriptor_blob(blob, blob_len, intros, intros_cap, intros_len) == 0) {
+                free(blob);
+                free(resp);
+                return 0;
+            }
+            free(blob);
+        }
+        free(resp);
+    }
+    return -1;
+}
+
+static int publish_descriptor(hidden_state_t *st) {
+    uint32_t ep = epoch_now();
+
+    // choose intro points randomly from relays
+    pcomm_peer_t rel[3]; size_t rel_n = 0;
+    load_onion_relays(st->db, st->me.user_id, NULL, NULL, rel, 3, &rel_n);
+    if (rel_n == 0) return -1;
+
+    pthread_mutex_lock(&st->lock);
+    st->intro_count = rel_n;
+    for (size_t i = 0; i < rel_n; i++) st->intros[i] = rel[i];
+    pthread_mutex_unlock(&st->lock);
+
+    uint8_t *blob = NULL; uint32_t blob_len = 0;
+    if (build_descriptor_blob(ep, rel, rel_n, &blob, &blob_len) != 0) return -1;
+
+    uint8_t dkey[32];
+    sha256_key("pcomm-desc-v1", st->me.user_id, ep, dkey);
+
+    uint8_t infohash[20];
+    pcomm_dht_infohash_desc(st->me.user_id, infohash);
+
+    // expires in ~12 hours
+    uint32_t expires = (uint32_t)(time(NULL) + 12*3600);
+
+    uint8_t *put = NULL; uint32_t put_len = 0;
+    if (ctrl_build_desc_put(infohash, dkey, expires, blob, blob_len, &put, &put_len) != 0) {
+        free(blob);
+        return -1;
+    }
+
+    // Store the descriptor on a few random relays. Those relays will announce themselves in the DHT
+    // (BEP-5 announce_peer) under our descriptor infohash.
+    for (size_t i = 0; i < rel_n; i++) {
+        onion_send_ctrl(st->db, &st->cfg, &st->me, &rel[i], put, put_len, 0, NULL, NULL);
+    }
+
+    free(put);
+    free(blob);
+    return 0;
+}
+
+static int parse_mb_resp_items(hidden_state_t *st, const uint8_t *payload, uint32_t payload_len) {
+    if (!payload || payload_len < 1 + 2) return -1;
+    uint32_t off = 0;
+    if (payload[off++] != (uint8_t)PCOMM_CTRL_MB_RESP) return -1;
+    if (payload_len < off + 2) return -1;
+    uint16_t count = get_u16(payload + off); off += 2;
+
+    for (uint16_t i = 0; i < count; i++) {
+        if (payload_len < off + 8 + 4 + 4) break;
+        // id (ignored)
+        off += 8;
+        uint32_t ts = get_u32(payload + off); off += 4;
+        uint32_t bl = get_u32(payload + off); off += 4;
+        if (payload_len < off + bl) break;
+        const uint8_t *sealed = payload + off;
+        off += bl;
+
+        uint8_t *plain = NULL; size_t plain_len = 0;
+        if (pcomm_open_seal(st->me.privkey, sealed, bl, &plain, &plain_len) != 0) continue;
+
+        pcomm_plain_kind_t kind;
+        uint32_t mts = 0;
+        char sender[96] = {0};
+        char group_uuid[64] = {0};
+        char *title = NULL;
+        char **members = NULL; int member_count = 0;
+        char *text = NULL;
+
+        if (pcomm_msg_unpack_any(plain, plain_len, &kind, &mts, sender, sizeof(sender),
+                                 group_uuid, sizeof(group_uuid),
+                                 &title, &members, &member_count, &text) == 0) {
+            if (kind == PCOMM_PLAIN_DIRECT_TEXT) {
+                int64_t conv_id = pcomm_db_get_or_create_direct_conv(st->db, sender);
+                if (conv_id >= 0) {
+                    pcomm_db_insert_message(st->db, conv_id, 0, sender, sender, text ? text : "", sealed, bl, (int64_t)(mts ? mts : ts));
+                }
+            } else if (kind == PCOMM_PLAIN_GROUP_INVITE) {
+                int64_t conv_id = pcomm_db_get_or_create_group_conv(st->db, group_uuid, title ? title : "");
+                if (conv_id >= 0) {
+                    // add participants
+                    for (int k = 0; k < member_count; k++) {
+                        pcomm_db_add_participant(st->db, conv_id, members[k]);
+                    }
+                    // store as a system message
+                    const char *body = title ? title : "Group invite";
+                    pcomm_db_insert_message(st->db, conv_id, 0, group_uuid, sender, body, sealed, bl, (int64_t)(mts ? mts : ts));
+                }
+            } else if (kind == PCOMM_PLAIN_GROUP_TEXT) {
+                int64_t conv_id = pcomm_db_get_or_create_group_conv(st->db, group_uuid, NULL);
+                if (conv_id >= 0) {
+                    pcomm_db_insert_message(st->db, conv_id, 0, group_uuid, sender, text ? text : "", sealed, bl, (int64_t)(mts ? mts : ts));
+                }
+            }
+        }
+
+        free(plain);
+        free(title);
+        pcomm_msg_free_members(members, member_count);
+        free(text);
+    }
+
+    return 0;
+}
+
+static int poll_mailbox_from_peer(hidden_state_t *st, const pcomm_peer_t *peer, const uint8_t infohash[20], const uint8_t mkey[32]) {
+    uint8_t *req = NULL; uint32_t req_len = 0;
+    if (ctrl_build_mb_get(infohash, mkey, &req, &req_len) != 0) return -1;
+
+    uint8_t *resp = NULL; uint32_t resp_len = 0;
+    int rc = onion_send_ctrl(st->db, &st->cfg, &st->me, peer, req, req_len, 1, &resp, &resp_len);
+    free(req);
+    if (rc != 0 || !resp) { free(resp); return -1; }
+
+    parse_mb_resp_items(st, resp, resp_len);
+    free(resp);
+    return 0;
+}
+
+static void *sync_thread(void *arg) {
+    hidden_state_t *st = (hidden_state_t*)arg;
+
+    for (;;) {
+        uint32_t ep = epoch_now();
+        uint8_t mkey_now[32];
+        sha256_key("pcomm-mb-v1", st->me.user_id, ep, mkey_now);
+        uint8_t mkey_prev[32];
+        sha256_key("pcomm-mb-v1", st->me.user_id, ep ? (ep-1) : ep, mkey_prev);
+
+        uint8_t infohash[20];
+        pcomm_dht_infohash_mb(st->me.user_id, infohash);
+
+        // Prefer DHT-discovered mailbox hosts
+        char hosts[8][64]; uint16_t ports[8]; size_t hn = 0;
+        if (pcomm_dht_get_peers_hosts(infohash, hosts, ports, 8, &hn) == 0 && hn > 0) {
+            for (size_t i = 0; i < hn; i++) {
+                pcomm_peer_t p; memset(&p, 0, sizeof(p));
+                snprintf(p.host, sizeof(p.host), "%s", hosts[i]);
+                p.port = ports[i];
+                poll_mailbox_from_peer(st, &p, infohash, mkey_now);
+                poll_mailbox_from_peer(st, &p, infohash, mkey_prev);
+            }
+        } else {
+            // Fallback: old HSDir selection
+            pcomm_peer_t hs[3]; size_t hs_len = 0;
+            if (select_hsdirs(st->db, st->me.user_id, ep, hs, &hs_len) == 0) {
+                for (size_t i = 0; i < hs_len; i++) {
+                    poll_mailbox_from_peer(st, &hs[i], infohash, mkey_now);
+                    poll_mailbox_from_peer(st, &hs[i], infohash, mkey_prev);
+                }
+            }
+        }
+
+        // Also poll intro points from last publish (extra redundancy)
+        pthread_mutex_lock(&st->lock);
+        pcomm_peer_t intros[3]; size_t intro_n = st->intro_count;
+        for (size_t i = 0; i < intro_n; i++) intros[i] = st->intros[i];
+        pthread_mutex_unlock(&st->lock);
+        for (size_t i = 0; i < intro_n; i++) {
+            poll_mailbox_from_peer(st, &intros[i], infohash, mkey_now);
+            poll_mailbox_from_peer(st, &intros[i], infohash, mkey_prev);
+        }
+
+        sleep(3);
+    }
+    return NULL;
+}
+
+static void *publish_thread(void *arg) {
+    hidden_state_t *st = (hidden_state_t*)arg;
+    for (;;) {
+        publish_descriptor(st);
+        sleep(10 * 60);
+    }
+    return NULL;
+}
+
+static void *cover_thread(void *arg) {
+    hidden_state_t *st = (hidden_state_t*)arg;
+    for (;;) {
+        // random jitter 2..6 seconds
+        uint8_t r[1];
+        pcomm_random(r, 1);
+        int delay = 2 + (r[0] % 5);
+
+        // pick a random relay as destination
+        pcomm_peer_t dest;
+        const char *sql = "SELECT user_id, host, port, pubkey FROM contacts WHERE is_relay=1 AND host!='' AND port>0 ORDER BY RANDOM() LIMIT 1;";
+        sqlite3_stmt *stq = NULL;
+        if (sqlite3_prepare_v2(st->db->db, sql, -1, &stq, NULL) == SQLITE_OK) {
+            if (sqlite3_step(stq) == SQLITE_ROW) {
+                const char *uid = (const char*)sqlite3_column_text(stq, 0);
+                const char *host = (const char*)sqlite3_column_text(stq, 1);
+                int port = sqlite3_column_int(stq, 2);
+                const void *pk = sqlite3_column_blob(stq, 3);
+                int pklen = sqlite3_column_bytes(stq, 3);
+                if (uid && host && pklen == 32 && port > 0 && port <= 65535) {
+                    memset(&dest, 0, sizeof(dest));
+                    snprintf(dest.user_id, sizeof(dest.user_id), "%s", uid);
+                    snprintf(dest.host, sizeof(dest.host), "%s", host);
+                    dest.port = (uint16_t)port;
+                    memcpy(dest.pubkey, pk, 32);
+
+                    uint8_t *noop = NULL; uint32_t noop_len = 0;
+                    if (ctrl_build_noop(&noop, &noop_len) == 0) {
+                        onion_send_ctrl(st->db, &st->cfg, &st->me, &dest, noop, noop_len, 0, NULL, NULL);
+                    }
+                    free(noop);
+                }
+            }
+        }
+        sqlite3_finalize(stq);
+
+        sleep(delay);
+    }
+    return NULL;
+}
+
+int pcomm_hidden_start(const pcomm_config_t *cfg, const pcomm_identity_t *me, pcomm_db_t *db) {
+    if (!cfg || !me || !db) return -1;
+
+    hidden_state_t *st = (hidden_state_t*)calloc(1, sizeof(hidden_state_t));
+    if (!st) return -1;
+    st->cfg = *cfg;
+    st->me = *me;
+    st->db = db;
+    pthread_mutex_init(&st->lock, NULL);
+
+    g_hidden = st;
+
+    pthread_t th1, th2, th3;
+    pthread_create(&th1, NULL, publish_thread, st);
+    pthread_detach(th1);
+    pthread_create(&th2, NULL, sync_thread, st);
+    pthread_detach(th2);
+    pthread_create(&th3, NULL, cover_thread, st);
+    pthread_detach(th3);
+
+    fprintf(stderr, "Hidden-service style mailbox started (publish/sync/cover)\n");
+    return 0;
+}
+
+int pcomm_hidden_mailbox_send(pcomm_db_t *db, const pcomm_config_t *cfg, const pcomm_identity_t *me,
+                             const char *recipient_id,
+                             const uint8_t *sealed, size_t sealed_len) {
+    if (!db || !cfg || !me || !recipient_id || !sealed || sealed_len == 0) return -1;
+
+    uint32_t ep = epoch_now();
+    uint8_t mkey[32];
+    sha256_key("pcomm-mb-v1", recipient_id, ep, mkey);
+
+    uint8_t infohash[20];
+    pcomm_dht_infohash_mb(recipient_id, infohash);
+
+    // Try descriptor -> intro points
+    pcomm_peer_t intros[3]; size_t intro_n = 0;
+    fetch_descriptor(db, cfg, me, recipient_id, ep, intros, 3, &intro_n);
+
+    uint8_t *put = NULL; uint32_t put_len = 0;
+    if (ctrl_build_mb_put(infohash, mkey, sealed, (uint32_t)sealed_len, &put, &put_len) != 0) return -1;
+
+    int ok = -1;
+
+    // Prefer DHT-discovered mailbox hosts
+    char hosts[8][64]; uint16_t ports[8]; size_t hn = 0;
+    if (pcomm_dht_get_peers_hosts(infohash, hosts, ports, 8, &hn) == 0 && hn > 0) {
+        size_t send_n = (hn > 3) ? 3 : hn;
+        for (size_t i = 0; i < send_n; i++) {
+            pcomm_peer_t dest; memset(&dest, 0, sizeof(dest));
+            snprintf(dest.host, sizeof(dest.host), "%s", hosts[i]);
+            dest.port = ports[i];
+            onion_send_ctrl(db, cfg, me, &dest, put, put_len, 0, NULL, NULL);
+            ok = 0;
+        }
+    }
+
+    // Also send to 1 intro point if available (extra redundancy)
+    if (intro_n > 0) {
+        onion_send_ctrl(db, cfg, me, &intros[0], put, put_len, 0, NULL, NULL);
+        ok = 0;
+    }
+
+    // Fallback: old deterministic HSDirs
+    if (ok != 0) {
+        pcomm_peer_t hs[3]; size_t hs_n = 0;
+        if (select_hsdirs(db, recipient_id, ep, hs, &hs_n) == 0) {
+            for (size_t i = 0; i < hs_n && i < 2; i++) {
+                onion_send_ctrl(db, cfg, me, &hs[i], put, put_len, 0, NULL, NULL);
+                ok = 0;
+            }
+        }
+    }
+
+    free(put);
+    return ok;
+}
+
+int pcomm_hidden_send_direct_text(pcomm_db_t *db, const pcomm_config_t *cfg, const pcomm_identity_t *me,
+                                 const char *to_user_id, const char *text) {
+    if (!db || !cfg || !me || !to_user_id || !text) return -1;
+
+    // recipient pubkey is self-certifying from the id
+    uint8_t recip_pub[32];
+    if (pcomm_pubkey_from_user_id(to_user_id, recip_pub) != 0) {
+        fprintf(stderr, "Bad recipient id\n");
+        return -1;
+    }
+
+    uint32_t ts = (uint32_t)time(NULL);
+
+    uint8_t *plain = NULL; size_t plain_len = 0;
+    if (pcomm_msg_pack_direct_text(ts, me->user_id, text, &plain, &plain_len) != 0) return -1;
+
+    uint8_t *sealed = NULL; size_t sealed_len = 0;
+    if (pcomm_seal_for_recipient(recip_pub, plain, plain_len, &sealed, &sealed_len) != 0) {
+        free(plain);
+        return -1;
+    }
+    free(plain);
+
+    int send_rc = pcomm_hidden_mailbox_send(db, cfg, me, to_user_id, sealed, sealed_len);
+
+    // Store outbound (direct)
+    int64_t conv_id = pcomm_db_get_or_create_direct_conv(db, to_user_id);
+    if (conv_id >= 0) {
+        pcomm_db_insert_message(db, conv_id, 1, to_user_id, me->user_id, text, sealed, sealed_len, (int64_t)ts);
+    }
+
+    free(sealed);
+    return send_rc;
+}
+
+int pcomm_hidden_send_group_invite(pcomm_db_t *db, const pcomm_config_t *cfg, const pcomm_identity_t *me,
+                                  const char *member_id,
+                                  const char *group_uuid, const char *title,
+                                  char **members, int member_count) {
+    if (!db || !cfg || !me || !member_id || !group_uuid) return -1;
+
+    uint8_t recip_pub[32];
+    if (pcomm_pubkey_from_user_id(member_id, recip_pub) != 0) return -1;
+
+    uint32_t ts = (uint32_t)time(NULL);
+    uint8_t *plain = NULL; size_t plain_len = 0;
+    if (pcomm_msg_pack_group_invite(ts, me->user_id, group_uuid, title, members, member_count, &plain, &plain_len) != 0) return -1;
+
+    uint8_t *sealed = NULL; size_t sealed_len = 0;
+    if (pcomm_seal_for_recipient(recip_pub, plain, plain_len, &sealed, &sealed_len) != 0) {
+        free(plain);
+        return -1;
+    }
+    free(plain);
+
+    int rc = pcomm_hidden_mailbox_send(db, cfg, me, member_id, sealed, sealed_len);
+    free(sealed);
+    return rc;
+}
+
+int pcomm_hidden_send_group_text(pcomm_db_t *db, const pcomm_config_t *cfg, const pcomm_identity_t *me,
+                                const char *member_id,
+                                const char *group_uuid, const char *text) {
+    if (!db || !cfg || !me || !member_id || !group_uuid || !text) return -1;
+
+    uint8_t recip_pub[32];
+    if (pcomm_pubkey_from_user_id(member_id, recip_pub) != 0) return -1;
+
+    uint32_t ts = (uint32_t)time(NULL);
+    uint8_t *plain = NULL; size_t plain_len = 0;
+    if (pcomm_msg_pack_group_text(ts, me->user_id, group_uuid, text, &plain, &plain_len) != 0) return -1;
+
+    uint8_t *sealed = NULL; size_t sealed_len = 0;
+    if (pcomm_seal_for_recipient(recip_pub, plain, plain_len, &sealed, &sealed_len) != 0) {
+        free(plain);
+        return -1;
+    }
+    free(plain);
+
+    int rc = pcomm_hidden_mailbox_send(db, cfg, me, member_id, sealed, sealed_len);
+    free(sealed);
+    return rc;
+}

--- a/src/hidden.h
+++ b/src/hidden.h
@@ -1,0 +1,31 @@
+#ifndef PCOMM_HIDDEN_H
+#define PCOMM_HIDDEN_H
+
+#include "pcomm.h"
+#include "db.h"
+
+// Starts background tasks:
+// - periodically publishes our descriptor (intro points) to HSDirs
+// - polls mailbox at our intro points and HSDirs and stores received messages
+// - generates cover traffic (padding) via NOOP onions
+int pcomm_hidden_start(const pcomm_config_t *cfg, const pcomm_identity_t *me, pcomm_db_t *db);
+
+// Send a sealed E2E blob to recipient by ID using descriptor/HSDir mailbox.
+int pcomm_hidden_mailbox_send(pcomm_db_t *db, const pcomm_config_t *cfg, const pcomm_identity_t *me,
+                              const char *recipient_id,
+                              const uint8_t *sealed, size_t sealed_len);
+
+// (Group) helpers built on top of mailbox send. These build sealed payloads.
+int pcomm_hidden_send_direct_text(pcomm_db_t *db, const pcomm_config_t *cfg, const pcomm_identity_t *me,
+                                  const char *to_user_id, const char *text);
+
+int pcomm_hidden_send_group_invite(pcomm_db_t *db, const pcomm_config_t *cfg, const pcomm_identity_t *me,
+                                   const char *member_id,
+                                   const char *group_uuid, const char *title,
+                                   char **members, int member_count);
+
+int pcomm_hidden_send_group_text(pcomm_db_t *db, const pcomm_config_t *cfg, const pcomm_identity_t *me,
+                                 const char *member_id,
+                                 const char *group_uuid, const char *text);
+
+#endif

--- a/src/http.c
+++ b/src/http.c
@@ -79,6 +79,7 @@ static int serve_file(int fd, const char *ui_dir, const char *req_path) {
     char path[1024];
     if (strcmp(req_path, "/") == 0) req_path = "/index.html";
 
+    // basic path traversal protection
     if (strstr(req_path, "..")) return send_resp(fd, 400, "text/plain", "bad path", 8);
 
     snprintf(path, sizeof(path), "%s%s", ui_dir, req_path);
@@ -190,11 +191,13 @@ static int api_conversations(http_state_t *st, int fd) {
 }
 
 static int api_messages(http_state_t *st, int fd, const char *query) {
+    // expect conv=<id>
     char conv_id_str[64] = {0};
     if (query) {
         const char *p = strstr(query, "conv=");
         if (p) {
             snprintf(conv_id_str, sizeof(conv_id_str), "%s", p + 5);
+            // strip after &
             char *amp = strchr(conv_id_str, '&');
             if (amp) *amp = '\0';
         }
@@ -250,9 +253,11 @@ static int api_send(http_state_t *st, int fd, const char *body) {
 
 static void trim(char *s) {
     if (!s) return;
+    // left
     char *p = s;
     while (*p && isspace((unsigned char)*p)) p++;
     if (p != s) memmove(s, p, strlen(p) + 1);
+    // right
     size_t n = strlen(s);
     while (n > 0 && isspace((unsigned char)s[n-1])) { s[n-1] = '\0'; n--; }
 }
@@ -276,6 +281,7 @@ static int api_create_group(http_state_t *st, int fd, const char *body) {
     trim(title);
     trim(members_raw);
 
+    // split by comma
     char *tmp = strdup(members_raw);
     if (!tmp) return send_resp(fd, 500, "text/plain", "oom", 3);
 
@@ -285,6 +291,7 @@ static int api_create_group(http_state_t *st, int fd, const char *body) {
     for (char *tok = strtok_r(tmp, ",", &save); tok && mcount < 64; tok = strtok_r(NULL, ",", &save)) {
         trim(tok);
         if (tok[0] == '\0') continue;
+        // validate ID format quickly (pubkey decode will validate more)
         uint8_t pk[32];
         if (pcomm_pubkey_from_user_id(tok, pk) != 0) continue;
         members[mcount++] = strdup(tok);
@@ -292,6 +299,7 @@ static int api_create_group(http_state_t *st, int fd, const char *body) {
     free(tmp);
     if (mcount == 0) return send_resp(fd, 400, "text/plain", "no valid members", 16);
 
+    // include self (if room)
     if (mcount < 65) members[mcount++] = strdup(st->me.user_id);
 
     uint8_t rnd[16];
@@ -308,6 +316,7 @@ static int api_create_group(http_state_t *st, int fd, const char *body) {
         pcomm_db_add_participant(st->db, conv_id, members[i]);
     }
 
+    // send invites to all other members
     for (int i = 0; i < mcount; i++) {
         if (strcmp(members[i], st->me.user_id) == 0) continue;
         pcomm_hidden_send_group_invite(st->db, &st->cfg, &st->me, members[i], uuid, title, members, mcount);
@@ -343,12 +352,14 @@ static int api_send_group(http_state_t *st, int fd, const char *body) {
         return send_resp(fd, 500, "text/plain", "db error", 8);
     }
 
+    // send to each member (except self)
     for (int i = 0; i < mcount; i++) {
         if (!members[i]) continue;
         if (strcmp(members[i], st->me.user_id) == 0) continue;
         pcomm_hidden_send_group_text(st->db, &st->cfg, &st->me, members[i], uuid, text);
     }
 
+    // store outbound locally
     pcomm_db_insert_message(st->db, conv_id, 1, uuid, st->me.user_id, text, (const uint8_t*)"", 0, (int64_t)time(NULL));
 
     for (int i = 0; i < mcount; i++) free(members[i]);
@@ -364,6 +375,7 @@ static int api_add_contact(http_state_t *st, int fd, const char *body) {
     char relay_str[8] = {0};
 
     if (form_get_field(body, "id", id, sizeof(id)) != 0) return send_resp(fd, 400, "text/plain", "missing id", 10);
+    // host/port are optional in the ID-only messaging model
     form_get_field(body, "host", host, sizeof(host));
     form_get_field(body, "port", port_str, sizeof(port_str));
     form_get_field(body, "relay", relay_str, sizeof(relay_str));
@@ -371,6 +383,7 @@ static int api_add_contact(http_state_t *st, int fd, const char *body) {
     uint16_t port = (uint16_t)atoi(port_str);
     int is_relay = (relay_str[0] == '1') ? 1 : 0;
 
+    // Extract pubkey from id
     uint8_t pubkey[32];
     if (pcomm_pubkey_from_user_id(id, pubkey) != 0) {
         return send_resp(fd, 400, "text/plain", "bad id", 6);
@@ -405,11 +418,13 @@ static void *http_thread(void *arg) {
         int cfd = net_accept(st->listen_fd, NULL, 0, NULL);
         if (cfd < 0) continue;
 
+        // read request headers
         char req[8192];
         ssize_t n = recv(cfd, req, sizeof(req) - 1, 0);
         if (n <= 0) { close(cfd); continue; }
         req[n] = '\0';
 
+        // split headers and body
         char *hdr_end = strstr(req, "\r\n\r\n");
         if (!hdr_end) { send_resp(cfd, 400, "text/plain", "bad request", 11); close(cfd); continue; }
 
@@ -417,6 +432,7 @@ static void *http_thread(void *arg) {
         char *body = req + header_len;
         size_t body_len = (size_t)n - header_len;
 
+        // parse request line
         char method[8] = {0};
         char target[1024] = {0};
         if (sscanf(req, "%7s %1023s", method, target) != 2) {
@@ -425,6 +441,7 @@ static void *http_thread(void *arg) {
             continue;
         }
 
+        // content-length
         size_t content_len = 0;
         const char *cl = strcasestr(req, "Content-Length:");
         if (cl) {
@@ -433,6 +450,7 @@ static void *http_thread(void *arg) {
             content_len = (size_t)atoi(cl);
         }
 
+        // if body incomplete, read rest (simple)
         while (body_len < content_len && header_len + body_len < sizeof(req) - 1) {
             ssize_t m = recv(cfd, req + n, (sizeof(req) - 1) - (size_t)n, 0);
             if (m <= 0) break;
@@ -448,6 +466,7 @@ static void *http_thread(void *arg) {
             continue;
         }
 
+        // path + query
         char path[1024] = {0};
         char *q = strchr(target, '?');
         const char *query = NULL;
@@ -461,6 +480,7 @@ static void *http_thread(void *arg) {
             snprintf(path, sizeof(path), "%s", target);
         }
 
+        // Ensure body is NUL terminated for form parsing
         char *body_copy = NULL;
         if (content_len > 0) {
             body_copy = (char*)malloc(content_len + 1);

--- a/src/http_util.h
+++ b/src/http_util.h
@@ -3,9 +3,14 @@
 
 #include <stddef.h>
 
+// Decodes percent-encoding in-place. Returns length.
 size_t url_decode_inplace(char *s);
+
+// Gets a form field from x-www-form-urlencoded body.
+// Writes decoded value into out. Returns 0 if found.
 int form_get_field(const char *body, const char *key, char *out, size_t out_cap);
 
+// Appends JSON-escaped version of s into sb (without surrounding quotes).
 #include "sb.h"
 int sb_append_json_escaped(sb_t *sb, const char *s);
 

--- a/src/identity.c
+++ b/src/identity.c
@@ -44,6 +44,7 @@ static int write_file_all_600(const char *path, const uint8_t *buf, size_t len) 
 int pcomm_user_id_from_pubkey(const uint8_t pubkey[32], char out[96]) {
     if (!pubkey || !out) return -1;
 
+    // payload: version(1) + pubkey(32) + checksum(4)
     uint8_t payload[1 + 32 + 4];
     payload[0] = 0x01;
     memcpy(payload + 1, pubkey, 32);
@@ -56,6 +57,7 @@ int pcomm_user_id_from_pubkey(const uint8_t pubkey[32], char out[96]) {
     int b32len = base32_encode_no_pad(payload, sizeof(payload), b32, sizeof(b32));
     if (b32len < 0) return -1;
 
+    // Prefix to make it recognizable.
     snprintf(out, 96, "pcomm1_%s", b32);
     return 0;
 }
@@ -103,6 +105,7 @@ int pcomm_identity_load_or_create(pcomm_identity_t *id, const char *data_dir) {
     if (!id || !data_dir) return -1;
     memset(id, 0, sizeof(*id));
 
+    // ensure data dir exists
     mkdir_p(data_dir);
 
     char key_path[1024];
@@ -116,6 +119,7 @@ int pcomm_identity_load_or_create(pcomm_identity_t *id, const char *data_dir) {
 
     if (read_file_all(key_path, id->privkey, 32) != 0) return -1;
 
+    // reconstruct EVP_PKEY to compute pubkey
     EVP_PKEY *pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_X25519, NULL, id->privkey, 32);
     if (!pkey) return -1;
     size_t pub_len = 32;

--- a/src/identity.h
+++ b/src/identity.h
@@ -3,10 +3,14 @@
 
 #include "pcomm.h"
 
+// Loads identity from data_dir/identity.key, or creates a new one.
+// Fills id->privkey/pubkey/user_id.
 int pcomm_identity_load_or_create(pcomm_identity_t *id, const char *data_dir);
 
+// Converts pubkey to user ID string.
 int pcomm_user_id_from_pubkey(const uint8_t pubkey[32], char out[96]);
 
+// Extracts pubkey from user ID (verifies checksum). Returns 0 on success.
 int pcomm_pubkey_from_user_id(const char *user_id, uint8_t pubkey_out[32]);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,8 @@
 #include "http.h"
 #include "mesh.h"
 #include "hidden.h"
+#include "dht.h"
+#include "circuit.h"
 
 #include <stdio.h>
 #include <signal.h>
@@ -59,7 +61,10 @@ int main(int argc, char **argv) {
         return 1;
     }
 
+    // Background network tasks
     pcomm_mesh_start(&cfg, &me, &db);
+    pcomm_dht_start(&cfg, &me, &db);
+    pcomm_circuits_start(&cfg, &me, &db);
     pcomm_hidden_start(&cfg, &me, &db);
 
     while (g_running) {

--- a/src/mesh.c
+++ b/src/mesh.c
@@ -1,0 +1,186 @@
+#include "mesh.h"
+#include "net.h"
+#include "proto.h"
+#include "identity.h"
+
+#include <pthread.h>
+#include <sqlite3.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+
+static void put_u16(uint8_t *p, uint16_t v){ uint16_t n=htons(v); memcpy(p,&n,2); }
+static uint16_t get_u16(const uint8_t *p){ uint16_t n; memcpy(&n,p,2); return ntohs(n); }
+
+static int pick_random_relay(pcomm_db_t *db, pcomm_peer_t *out) {
+    const char *sql = "SELECT user_id, host, port, pubkey FROM contacts WHERE is_relay=1 AND host!='' AND port>0 ORDER BY RANDOM() LIMIT 1;";
+    sqlite3_stmt *st = NULL;
+    if (sqlite3_prepare_v2(db->db, sql, -1, &st, NULL) != SQLITE_OK) return -1;
+    int rc = sqlite3_step(st);
+    if (rc != SQLITE_ROW) { sqlite3_finalize(st); return -1; }
+
+    const char *uid = (const char*)sqlite3_column_text(st, 0);
+    const char *host = (const char*)sqlite3_column_text(st, 1);
+    int port = sqlite3_column_int(st, 2);
+    const void *pk = sqlite3_column_blob(st, 3);
+    int pklen = sqlite3_column_bytes(st, 3);
+
+    if (!uid || !host || pklen != 32 || port <= 0 || port > 65535) { sqlite3_finalize(st); return -1; }
+    memset(out, 0, sizeof(*out));
+    snprintf(out->user_id, sizeof(out->user_id), "%s", uid);
+    snprintf(out->host, sizeof(out->host), "%s", host);
+    out->port = (uint16_t)port;
+    memcpy(out->pubkey, pk, 32);
+
+    sqlite3_finalize(st);
+    return 0;
+}
+
+static int build_hello(const pcomm_config_t *cfg, const pcomm_identity_t *me, uint8_t **out, uint32_t *out_len) {
+    const char *adv_host = (cfg->advertise_host[0] != '\0') ? cfg->advertise_host : cfg->relay_host;
+    uint16_t adv_port = (cfg->advertise_port != 0) ? cfg->advertise_port : cfg->relay_port;
+    if (strcmp(adv_host, "0.0.0.0") == 0) adv_host = "127.0.0.1"; // last-resort
+
+    size_t uid_len = strlen(me->user_id);
+    size_t host_len = strlen(adv_host);
+    if (uid_len > 255 || host_len > 63) return -1;
+
+    uint32_t len = 1 + 2 + (uint32_t)uid_len + 1 + (uint32_t)host_len + 2 + 32;
+    uint8_t *buf = (uint8_t*)malloc(len);
+    if (!buf) return -1;
+
+    uint32_t off = 0;
+    buf[off++] = (uint8_t)PCOMM_CTRL_HELLO;
+    put_u16(buf + off, (uint16_t)uid_len); off += 2;
+    memcpy(buf + off, me->user_id, uid_len); off += (uint32_t)uid_len;
+    buf[off++] = (uint8_t)host_len;
+    memcpy(buf + off, adv_host, host_len); off += (uint32_t)host_len;
+    put_u16(buf + off, adv_port); off += 2;
+    memcpy(buf + off, me->pubkey, 32); off += 32;
+
+    if (off != len) { free(buf); return -1; }
+    *out = buf; *out_len = len;
+    return 0;
+}
+
+static int build_peers_req(uint16_t want, uint8_t **out, uint32_t *out_len) {
+    uint8_t *buf = (uint8_t*)malloc(1 + 2);
+    if (!buf) return -1;
+    buf[0] = (uint8_t)PCOMM_CTRL_PEERS_REQ;
+    put_u16(buf + 1, want);
+    *out = buf; *out_len = 3;
+    return 0;
+}
+
+static int parse_peers_resp(pcomm_db_t *db, const uint8_t *payload, uint32_t payload_len) {
+    if (!payload || payload_len < 1 + 2) return -1;
+    uint32_t off = 0;
+    uint8_t cmd = payload[off++];
+    if (cmd != PCOMM_CTRL_PEERS_RESP) return -1;
+    uint16_t count = get_u16(payload + off); off += 2;
+
+    for (uint16_t i = 0; i < count; i++) {
+        if (payload_len < off + 2) break;
+        uint16_t uid_len = get_u16(payload + off); off += 2;
+        if (uid_len == 0 || uid_len > 95 || payload_len < off + uid_len) break;
+        char uid[128];
+        memcpy(uid, payload + off, uid_len); uid[uid_len] = '\0';
+        off += uid_len;
+
+        if (payload_len < off + 1) break;
+        uint8_t hlen = payload[off++];
+        if (hlen == 0 || hlen > 63 || payload_len < off + hlen + 2 + 32) break;
+        char host[128];
+        memcpy(host, payload + off, hlen); host[hlen] = '\0';
+        off += hlen;
+
+        uint16_t port = get_u16(payload + off); off += 2;
+        uint8_t pk[32];
+        memcpy(pk, payload + off, 32); off += 32;
+
+        // verify uid matches pk
+        char derived[96];
+        if (pcomm_user_id_from_pubkey(pk, derived) != 0) continue;
+        if (strcmp(uid, derived) != 0) continue;
+        if (port == 0) continue;
+
+        pcomm_db_upsert_contact(db, uid, host, port, pk, 1);
+    }
+    return 0;
+}
+
+typedef struct {
+    pcomm_config_t cfg;
+    pcomm_identity_t me;
+    pcomm_db_t *db;
+} mesh_state_t;
+
+static void *mesh_thread(void *arg) {
+    mesh_state_t *st = (mesh_state_t*)arg;
+
+    for (;;) {
+        // try to learn from a random relay
+        pcomm_peer_t peer;
+        if (pick_random_relay(st->db, &peer) == 0) {
+            // HELLO (one-shot connection)
+            {
+                int fd = net_connect_tcp(peer.host, peer.port);
+                if (fd >= 0) {
+                    uint8_t *hello = NULL; uint32_t hello_len = 0;
+                    if (build_hello(&st->cfg, &st->me, &hello, &hello_len) == 0) {
+                        pcomm_send_packet(fd, PCOMM_MSG_CTRL, NULL, hello, hello_len);
+                    }
+                    free(hello);
+                    close(fd);
+                }
+            }
+
+            // PEERS_REQ -> PEERS_RESP (one-shot connection)
+            {
+                int fd = net_connect_tcp(peer.host, peer.port);
+                if (fd >= 0) {
+                    uint8_t *req = NULL; uint32_t req_len = 0;
+                    if (build_peers_req(64, &req, &req_len) == 0) {
+                        if (pcomm_send_packet(fd, PCOMM_MSG_CTRL, NULL, req, req_len) == 0) {
+                            pcomm_msg_type_t rtype;
+                            uint8_t eph[32];
+                            uint8_t *rp = NULL; uint32_t rpl = 0;
+                            if (pcomm_recv_packet(fd, &rtype, eph, &rp, &rpl) == 0) {
+                                if (rtype == PCOMM_MSG_CTRL) {
+                                    parse_peers_resp(st->db, rp, rpl);
+                                }
+                                free(rp);
+                            }
+                        }
+                    }
+                    free(req);
+                    close(fd);
+                }
+            }
+        }
+
+        sleep(5);
+    }
+    return NULL;
+}
+
+int pcomm_mesh_start(const pcomm_config_t *cfg, const pcomm_identity_t *me, pcomm_db_t *db) {
+    if (!cfg || !me || !db) return -1;
+
+    mesh_state_t *st = (mesh_state_t*)calloc(1, sizeof(mesh_state_t));
+    if (!st) return -1;
+    st->cfg = *cfg;
+    st->me = *me;
+    st->db = db;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, mesh_thread, st) != 0) {
+        free(st);
+        return -1;
+    }
+    pthread_detach(th);
+    fprintf(stderr, "Mesh gossip started\n");
+    return 0;
+}

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -1,0 +1,11 @@
+#ifndef PCOMM_MESH_H
+#define PCOMM_MESH_H
+
+#include "pcomm.h"
+#include "db.h"
+
+// Starts a background thread that gossips relay peers (HELLO + PEERS_REQ)
+// to help new nodes join and maintain a dense mesh.
+int pcomm_mesh_start(const pcomm_config_t *cfg, const pcomm_identity_t *me, pcomm_db_t *db);
+
+#endif

--- a/src/msg.c
+++ b/src/msg.c
@@ -14,6 +14,8 @@ int pcomm_msg_pack_direct_text(uint32_t ts_unix, const char *sender_id, const ch
     size_t sid_len = strlen(sender_id);
     size_t tlen = strlen(text);
     if (sid_len > 90) return -1;
+
+    // ver(1) kind(1) ts(4) sid_len(2) sid text_len(4) text
     size_t len = 1 + 1 + 4 + 2 + sid_len + 4 + tlen;
     uint8_t *buf = (uint8_t*)malloc(len);
     if (!buf) return -1;
@@ -51,7 +53,7 @@ int pcomm_msg_pack_group_invite(uint32_t ts_unix, const char *sender_id,
         members_bytes += 2 + ml;
     }
 
-    // ver kind ts sid uuid title member_count(u16) members... bro wtf am I doing
+    // ver kind ts sid uuid title member_count(u16) members...
     size_t len = 1 + 1 + 4 + 2 + sid_len + 1 + uuid_len + 2 + title_len + 2 + members_bytes;
     uint8_t *buf = (uint8_t*)malloc(len);
     if (!buf) return -1;
@@ -163,7 +165,7 @@ int pcomm_msg_unpack_any(const uint8_t *buf, size_t len,
     if (len < 1 + 1 + 4 + 2) return -1;
 
     size_t off = 0;
-    off++;
+    off++; // ver
     uint8_t kind = buf[off++];
     *kind_out = (pcomm_plain_kind_t)kind;
 
@@ -226,6 +228,7 @@ int pcomm_msg_unpack_any(const uint8_t *buf, size_t len,
             *members_out_malloc = arr;
             *member_count_out = (int)mcount;
         } else {
+            // skip members
             for (uint16_t i = 0; i < mcount; i++) {
                 if (len < off + 2) return -1;
                 uint16_t ml = get_u16(buf + off); off += 2;

--- a/src/msg.h
+++ b/src/msg.h
@@ -4,6 +4,14 @@
 #include <stdint.h>
 #include <stddef.h>
 
+// Plaintext format (sealed end-to-end):
+// v2:
+//   ver(u8=2) kind(u8) ts(u32)
+//   sender_len(u16) sender
+//   ... kind-specific
+// v1 (legacy):
+//   ver(u8=1) ts(u32) sender_len(u16) sender text_len(u32) text
+
 typedef enum {
     PCOMM_PLAIN_DIRECT_TEXT = 1,
     PCOMM_PLAIN_GROUP_INVITE = 2,
@@ -22,6 +30,10 @@ int pcomm_msg_pack_group_text(uint32_t ts_unix, const char *sender_id,
                               const char *group_uuid, const char *text,
                               uint8_t **out, size_t *out_len);
 
+// Unpack any supported version.
+// For DIRECT_TEXT: text_out_malloc is set.
+// For GROUP_INVITE: group_uuid_out, title_out_malloc, members_out_malloc/member_count_out are set.
+// For GROUP_TEXT: group_uuid_out and text_out_malloc are set.
 int pcomm_msg_unpack_any(const uint8_t *buf, size_t len,
                          pcomm_plain_kind_t *kind_out,
                          uint32_t *ts_unix_out,
@@ -31,7 +43,7 @@ int pcomm_msg_unpack_any(const uint8_t *buf, size_t len,
                          char ***members_out_malloc, int *member_count_out,
                          char **text_out_malloc);
 
-// Why does VSC auto format de code like this
+// helpers to free arrays from unpack
 void pcomm_msg_free_members(char **members, int count);
 
 #endif

--- a/src/onion.c
+++ b/src/onion.c
@@ -65,6 +65,9 @@ int pcomm_onion_build_v1(const pcomm_peer_t *path, size_t path_len,
 
     size_t dest_host_len = strlen(dest_host);
     if (dest_host_len > 63) return -1;
+
+    // Innermost plaintext: DELIVER
+    // inst(1) flags(1) hostlen(1) host hostport(2) deliver_type(1) payload_len(4) payload
     uint8_t flags = (roundtrip != 0) ? 0x01 : 0x00;
     size_t pt0_len = 1 + 1 + 1 + dest_host_len + 2 + 1 + 4 + deliver_len;
     uint8_t *pt0 = (uint8_t*)malloc(pt0_len);
@@ -81,6 +84,7 @@ int pcomm_onion_build_v1(const pcomm_peer_t *path, size_t path_len,
     memcpy(pt0 + off, deliver_payload, deliver_len); off += deliver_len;
     if (off != pt0_len) { free(pt0); return -1; }
 
+    // Encrypt innermost for exit relay
     uint8_t *inner_blob = NULL;
     uint32_t inner_len = 0;
     {
@@ -105,11 +109,14 @@ int pcomm_onion_build_v1(const pcomm_peer_t *path, size_t path_len,
     }
     free(pt0);
 
+    // Wrap through relays in reverse.
     for (ssize_t i = (ssize_t)path_len - 2; i >= 0; i--) {
         const char *next_host = path[i+1].host;
         uint16_t next_port = path[i+1].port;
         size_t next_host_len = strlen(next_host);
         if (next_host_len > 63) { free(inner_blob); return -1; }
+
+        // inst(1) hostlen(1) host port(2) inner_len(4) inner
         uint8_t inst = (roundtrip != 0) ? (uint8_t)PCOMM_INST_FORWARD_RR : (uint8_t)PCOMM_INST_FORWARD;
         size_t pt_len = 1 + 1 + next_host_len + 2 + 4 + inner_len;
         uint8_t *pt = (uint8_t*)malloc(pt_len);

--- a/src/onion.h
+++ b/src/onion.h
@@ -5,6 +5,15 @@
 #include <stddef.h>
 #include <stdint.h>
 
+// Onion payload format (at each hop): nonce(12) || AEAD(ciphertext)
+// The decrypted plaintext begins with a single-byte instruction.
+//
+// pcomm_onion_build_v1 builds an onion payload to route through `path` relays (path_len >= 1),
+// ending at the last relay (exit). The exit will connect to dest_host:dest_port and send
+// `deliver_type` with `deliver_payload`.
+//
+// If roundtrip != 0, all FORWARD layers are built as FORWARD_RR and the DELIVER layer carries
+// a flag that asks the exit to read a single response packet and return it along the chain.
 int pcomm_onion_build_v1(const pcomm_peer_t *path, size_t path_len,
                          const char *dest_host, uint16_t dest_port,
                          pcomm_msg_type_t deliver_type,
@@ -13,6 +22,11 @@ int pcomm_onion_build_v1(const pcomm_peer_t *path, size_t path_len,
                          uint8_t eph_pub_out[32],
                          uint8_t **onion_payload_out, uint32_t *onion_payload_len_out);
 
+// Unwrap at a relay.
+//
+// If inst_out is FORWARD or FORWARD_RR, next_host/next_port and next_payload are returned.
+// If inst_out is DELIVER, dest_host/dest_port, deliver_type, deliver_flags and deliver_payload are returned.
+// deliver_flags bit0 = expect response.
 int pcomm_onion_unwrap_v1(const uint8_t relay_priv[32], const uint8_t eph_pub[32],
                           const uint8_t *payload, uint32_t payload_len,
                           pcomm_inst_t *inst_out,

--- a/src/pcomm.h
+++ b/src/pcomm.h
@@ -12,22 +12,48 @@ extern "C" {
 #define PCOMM_MAGIC "PCOM"
 #define PCOMM_VERSION 1
 
+// Network message types
 typedef enum {
     PCOMM_MSG_ONION  = 1,
     PCOMM_MSG_DELIVER = 2,
     PCOMM_MSG_CTRL = 3,
+    // Long-lived circuit cells (Tor-like relay cells + control)
+    PCOMM_MSG_CELL = 4,
 } pcomm_msg_type_t;
 
+// CELL commands (unencrypted; payload depends on cmd)
+typedef enum {
+    PCOMM_CELL_CREATE   = 1,
+    PCOMM_CELL_CREATED  = 2,
+    PCOMM_CELL_RELAY    = 3,
+    PCOMM_CELL_DESTROY  = 4,
+    PCOMM_CELL_PADDING  = 5,
+} pcomm_cell_cmd_t;
+
+// RELAY commands (encrypted end-to-end to the current exit)
+typedef enum {
+    PCOMM_RELAY_EXTEND    = 1,
+    PCOMM_RELAY_EXTENDED  = 2,
+    PCOMM_RELAY_BEGIN     = 3,
+    PCOMM_RELAY_CONNECTED = 4,
+    PCOMM_RELAY_DATA      = 5,
+    PCOMM_RELAY_END       = 6,
+} pcomm_relay_cmd_t;
+
+// Onion instruction
 typedef enum {
     PCOMM_INST_FORWARD = 1,
     PCOMM_INST_DELIVER = 2,
+    // Like FORWARD but relays a single response packet back to the previous hop.
     PCOMM_INST_FORWARD_RR = 3,
 } pcomm_inst_t;
 
+// CTRL commands (payload[0])
 typedef enum {
     PCOMM_CTRL_HELLO = 1,
     PCOMM_CTRL_PEERS_REQ = 2,
     PCOMM_CTRL_PEERS_RESP = 3,
+    // DESC/MB payloads now include a 20-byte BEP-5 infohash prefix so storage nodes can announce themselves.
     PCOMM_CTRL_DESC_PUT = 4,
     PCOMM_CTRL_DESC_GET = 5,
     PCOMM_CTRL_DESC_RESP = 6,
@@ -38,7 +64,7 @@ typedef enum {
 } pcomm_ctrl_cmd_t;
 
 typedef struct {
-    char user_id[96];
+    char user_id[96];       // printable identifier
     uint8_t pubkey[32];
     char host[64];
     uint16_t port;
@@ -49,6 +75,7 @@ typedef struct {
     char ui_dir[512];
     char relay_host[64];
     uint16_t relay_port;
+    // Publicly advertised relay address for mesh discovery (HELLO). If empty, relay_host/relay_port is used.
     char advertise_host[64];
     uint16_t advertise_port;
     char http_host[64];

--- a/src/peers.c
+++ b/src/peers.c
@@ -13,6 +13,7 @@ int pcomm_load_peers_file(pcomm_db_t *db, const char *peers_path) {
     char line[512];
     int count = 0;
     while (fgets(line, sizeof(line), f)) {
+        // strip newline
         char *nl = strchr(line, '\n');
         if (nl) *nl = '\0';
         if (line[0] == '#' || line[0] == '\0') continue;

--- a/src/peers.h
+++ b/src/peers.h
@@ -3,6 +3,7 @@
 
 #include "db.h"
 
+// Loads peers from text file and inserts/updates them as contacts with is_relay=1.
 int pcomm_load_peers_file(pcomm_db_t *db, const char *peers_path);
 
 #endif

--- a/src/proto.c
+++ b/src/proto.c
@@ -12,6 +12,7 @@ int pcomm_send_packet(int fd, pcomm_msg_type_t type, const uint8_t eph_pub[32], 
     memcpy(hdr, PCOMM_MAGIC, 4);
     hdr[4] = PCOMM_VERSION;
     hdr[5] = (uint8_t)type;
+    // hdr[6..7] reserved
 
     uint32_t nlen = htonl(payload_len);
     memcpy(hdr + 8, &nlen, 4);
@@ -54,5 +55,51 @@ int pcomm_recv_packet(int fd, pcomm_msg_type_t *type_out, uint8_t eph_pub_out[32
     }
 
     *payload_out = payload;
+    return 0;
+}
+
+int pcomm_pack_packet(pcomm_msg_type_t type, const uint8_t eph_pub[32], const uint8_t *payload, uint32_t payload_len,
+                      uint8_t **out, uint32_t *out_len) {
+    if (!out || !out_len) return -1;
+    *out = NULL; *out_len = 0;
+
+    uint32_t total = PCOMM_HDR_LEN + payload_len;
+    uint8_t *buf = (uint8_t*)malloc(total);
+    if (!buf) return -1;
+
+    memset(buf, 0, PCOMM_HDR_LEN);
+    memcpy(buf, PCOMM_MAGIC, 4);
+    buf[4] = PCOMM_VERSION;
+    buf[5] = (uint8_t)type;
+    uint32_t nlen = htonl(payload_len);
+    memcpy(buf + 8, &nlen, 4);
+    if (eph_pub) memcpy(buf + 12, eph_pub, 32);
+    if (payload_len && payload) memcpy(buf + PCOMM_HDR_LEN, payload, payload_len);
+
+    *out = buf;
+    *out_len = total;
+    return 0;
+}
+
+int pcomm_unpack_packet(const uint8_t *buf, uint32_t buf_len, pcomm_msg_type_t *type_out, uint8_t eph_pub_out[32],
+                        uint8_t **payload_out, uint32_t *payload_len_out) {
+    if (!buf || buf_len < PCOMM_HDR_LEN || !type_out || !payload_out || !payload_len_out) return -1;
+
+    if (memcmp(buf, PCOMM_MAGIC, 4) != 0) return -1;
+    if (buf[4] != PCOMM_VERSION) return -1;
+    *type_out = (pcomm_msg_type_t)buf[5];
+    uint32_t nlen;
+    memcpy(&nlen, buf + 8, 4);
+    uint32_t pl = ntohl(nlen);
+    if (PCOMM_HDR_LEN + pl != buf_len) return -1;
+    if (eph_pub_out) memcpy(eph_pub_out, buf + 12, 32);
+    uint8_t *payload = NULL;
+    if (pl > 0) {
+        payload = (uint8_t*)malloc(pl);
+        if (!payload) return -1;
+        memcpy(payload, buf + PCOMM_HDR_LEN, pl);
+    }
+    *payload_out = payload;
+    *payload_len_out = pl;
     return 0;
 }

--- a/src/proto.h
+++ b/src/proto.h
@@ -6,9 +6,22 @@
 #include <stdint.h>
 
 #define PCOMM_EPH_PUB_LEN 32
+
+// Header: magic(4) version(1) type(1) rsv(2) payload_len(4) eph_pub(32)
 #define PCOMM_HDR_LEN (4+1+1+2+4+32)
 
 int pcomm_send_packet(int fd, pcomm_msg_type_t type, const uint8_t eph_pub[32], const uint8_t *payload, uint32_t payload_len);
+
+// Allocates payload; caller frees.
 int pcomm_recv_packet(int fd, pcomm_msg_type_t *type_out, uint8_t eph_pub_out[32], uint8_t **payload_out, uint32_t *payload_len_out);
+
+// Helpers for stream-multiplexing: build a complete packet into a buffer.
+// Allocates *out; caller frees.
+int pcomm_pack_packet(pcomm_msg_type_t type, const uint8_t eph_pub[32], const uint8_t *payload, uint32_t payload_len,
+                      uint8_t **out, uint32_t *out_len);
+
+// Parse a complete packet from a buffer. Allocates *payload_out; caller frees.
+int pcomm_unpack_packet(const uint8_t *buf, uint32_t buf_len, pcomm_msg_type_t *type_out, uint8_t eph_pub_out[32],
+                        uint8_t **payload_out, uint32_t *payload_len_out);
 
 #endif

--- a/src/relay.c
+++ b/src/relay.c
@@ -6,6 +6,8 @@
 #include "msg.h"
 #include "identity.h"
 #include "db.h"
+#include "cell.h"
+#include "dht.h"
 
 #include <pthread.h>
 #include <stdio.h>
@@ -15,6 +17,7 @@
 #include <time.h>
 #include <arpa/inet.h>
 #include <sqlite3.h>
+#include <sys/select.h>
 
 typedef struct {
     pcomm_config_t cfg;
@@ -41,9 +44,11 @@ static int ctrl_send_peers_resp(relay_state_t *st, int fd, uint16_t want) {
     sqlite3_stmt *q = NULL;
     if (sqlite3_prepare_v2(st->db->db, sql, -1, &q, NULL) != SQLITE_OK) return -1;
     sqlite3_bind_int(q, 1, (int)want);
+
+    // First pass: count and size
     struct item { const char *uid; const char *host; int port; const void *pk; int pklen; } items[200];
     int count = 0;
-    size_t total = 1 + 2;
+    size_t total = 1 + 2; // cmd + count
 
     while (sqlite3_step(q) == SQLITE_ROW && count < (int)want) {
         const char *uid = (const char*)sqlite3_column_text(q, 0);
@@ -111,6 +116,8 @@ static int ctrl_handle(relay_state_t *st, int fd, const uint8_t *payload, uint32
         uint16_t port = get_u16(payload + off); off += 2;
         uint8_t pk[32];
         memcpy(pk, payload + off, 32);
+
+        // verify
         char derived[96];
         if (pcomm_user_id_from_pubkey(pk, derived) != 0) return 0;
         if (strcmp(uid, derived) != 0) return 0;
@@ -126,7 +133,10 @@ static int ctrl_handle(relay_state_t *st, int fd, const uint8_t *payload, uint32
     }
 
     if (cmd == PCOMM_CTRL_DESC_PUT) {
-        if (payload_len < off + 32 + 4 + 4) return 0;
+        // payload: cmd(1) infohash(20) dkey(32) expires(4) bloblen(4) blob
+        if (payload_len < off + 20 + 32 + 4 + 4) return 0;
+        uint8_t infohash[20];
+        memcpy(infohash, payload + off, 20); off += 20;
         uint8_t dkey[32];
         memcpy(dkey, payload + off, 32); off += 32;
         uint32_t expires = get_u32(payload + off); off += 4;
@@ -134,11 +144,16 @@ static int ctrl_handle(relay_state_t *st, int fd, const uint8_t *payload, uint32
         if (payload_len < off + bl) return 0;
         int64_t now = (int64_t)time(NULL);
         pcomm_db_desc_put(st->db, dkey, payload + off, bl, (int64_t)expires, now);
+        // announce ourselves as a descriptor host
+        pcomm_dht_announce(infohash, st->cfg.relay_port);
         return 0;
     }
 
     if (cmd == PCOMM_CTRL_DESC_GET) {
-        if (payload_len < off + 32) return 0;
+        // payload: cmd(1) infohash(20) dkey(32)
+        if (payload_len < off + 20 + 32) return 0;
+        // infohash unused for get
+        off += 20;
         uint8_t dkey[32];
         memcpy(dkey, payload + off, 32);
 
@@ -163,23 +178,31 @@ static int ctrl_handle(relay_state_t *st, int fd, const uint8_t *payload, uint32
     }
 
     if (cmd == PCOMM_CTRL_MB_PUT) {
-        if (payload_len < off + 32 + 4) return 0;
+        // payload: cmd(1) infohash(20) mkey(32) bloblen(4) blob
+        if (payload_len < off + 20 + 32 + 4) return 0;
+        uint8_t infohash[20];
+        memcpy(infohash, payload + off, 20); off += 20;
         uint8_t mkey[32];
         memcpy(mkey, payload + off, 32); off += 32;
         uint32_t bl = get_u32(payload + off); off += 4;
         if (payload_len < off + bl) return 0;
         int64_t now = (int64_t)time(NULL);
         pcomm_db_mailbox_put(st->db, mkey, payload + off, bl, now);
+        // announce ourselves as a mailbox host
+        pcomm_dht_announce(infohash, st->cfg.relay_port);
         return 0;
     }
 
     if (cmd == PCOMM_CTRL_MB_GET) {
-        if (payload_len < off + 32) return 0;
+        // payload: cmd(1) infohash(20) mkey(32)
+        if (payload_len < off + 20 + 32) return 0;
+        off += 20;
         uint8_t mkey[32];
         memcpy(mkey, payload + off, 32);
 
         uint8_t *body = NULL; uint32_t body_len = 0;
         if (pcomm_db_mailbox_get_and_delete(st->db, mkey, &body, &body_len) != 0) {
+            // empty response
             body = (uint8_t*)malloc(2);
             if (!body) return -1;
             body[0] = 0; body[1] = 0;
@@ -197,6 +220,316 @@ static int ctrl_handle(relay_state_t *st, int fd, const uint8_t *payload, uint32
         return 0;
     }
 
+    // NOOP or unknown
+    return 0;
+}
+
+// ---- Long-lived circuits (CELL) ----
+
+typedef struct {
+    int up_fd;
+    int down_fd; // -1 if exit
+    int built;
+    uint8_t k_fwd[32];
+    uint8_t k_bwd[32];
+
+    // exit-side stream buffering (very small prototype)
+    struct {
+        uint16_t id;
+        int used;
+        int expect_resp;
+        char host[64];
+        uint16_t port;
+        uint8_t *req;
+        uint32_t req_len;
+    } streams[32];
+} cell_conn_t;
+
+static int derive_hop_keys(const uint8_t shared[32], uint8_t out_fwd[32], uint8_t out_bwd[32]) {
+    const uint8_t salt[] = "pcomm-circ-v1";
+    const uint8_t info[] = "pcomm-hop-keys";
+    uint8_t okm[64];
+    if (pcomm_hkdf_sha256(shared, 32, salt, sizeof(salt)-1, info, sizeof(info)-1, okm, sizeof(okm)) != 0) return -1;
+    memcpy(out_fwd, okm, 32);
+    memcpy(out_bwd, okm + 32, 32);
+    return 0;
+}
+
+static int send_cell_link(int fd, uint8_t cmd, const uint8_t *payload, uint16_t payload_len) {
+    uint8_t *cell = NULL; uint32_t cell_len = 0;
+    if (pcomm_cell_pack(1, cmd, 0, payload, payload_len, &cell, &cell_len) != 0) return -1;
+    int rc = pcomm_send_packet(fd, PCOMM_MSG_CELL, NULL, cell, cell_len);
+    free(cell);
+    return rc;
+}
+
+static int recv_cell_link(int fd, uint8_t *cmd_out, uint8_t **payload_out, uint16_t *payload_len_out) {
+    *payload_out = NULL; *payload_len_out = 0; *cmd_out = 0;
+    pcomm_msg_type_t t; uint8_t eph[32]; uint8_t *p=NULL; uint32_t pl=0;
+    if (pcomm_recv_packet(fd, &t, eph, &p, &pl) != 0) { free(p); return -1; }
+    if (t != PCOMM_MSG_CELL) { free(p); return -1; }
+    uint32_t cid; uint8_t cmd, flags; const uint8_t *cpl; uint16_t cpll;
+    if (pcomm_cell_unpack(p, pl, &cid, &cmd, &flags, &cpl, &cpll) != 0 || cid != 1) { free(p); return -1; }
+    (void)flags;
+    *cmd_out = cmd;
+    if (cpll) {
+        uint8_t *cp = (uint8_t*)malloc(cpll);
+        if (!cp) { free(p); return -1; }
+        memcpy(cp, cpl, cpll);
+        *payload_out = cp;
+        *payload_len_out = cpll;
+    }
+    free(p);
+    return 0;
+}
+
+static int exit_send_relay_plain(cell_conn_t *cc, uint8_t relay_cmd, uint16_t stream_id, const uint8_t *body, uint16_t body_len) {
+    uint8_t *plain=NULL; uint16_t plain_len=0;
+    if (pcomm_relay_plain_pack(relay_cmd, stream_id, body, body_len, &plain, &plain_len) != 0) return -1;
+    uint8_t *wrapped=NULL; uint16_t wrapped_len=0;
+    if (pcomm_relay_wrap_one_backward(cc->k_bwd, 1, plain, plain_len, &wrapped, &wrapped_len) != 0) {
+        free(plain);
+        return -1;
+    }
+    free(plain);
+    int rc = send_cell_link(cc->up_fd, PCOMM_CELL_RELAY, wrapped, wrapped_len);
+    free(wrapped);
+    return rc;
+}
+
+static int exit_process_stream_done(cell_conn_t *cc, uint16_t sid) {
+    // find stream
+    int idx = -1;
+    for (int i=0;i<32;i++) if (cc->streams[i].used && cc->streams[i].id == sid) { idx=i; break; }
+    if (idx < 0) return -1;
+    // connect dest
+    int fd = net_connect_tcp(cc->streams[idx].host, cc->streams[idx].port);
+    if (fd < 0) {
+        cc->streams[idx].used = 0;
+        free(cc->streams[idx].req);
+        cc->streams[idx].req = NULL;
+        cc->streams[idx].req_len = 0;
+        return exit_send_relay_plain(cc, PCOMM_RELAY_END, sid, NULL, 0);
+    }
+    // send raw request bytes
+    if (net_sendall(fd, cc->streams[idx].req, cc->streams[idx].req_len) != 0) {
+        close(fd);
+        cc->streams[idx].used = 0;
+        free(cc->streams[idx].req);
+        cc->streams[idx].req = NULL;
+        cc->streams[idx].req_len = 0;
+        return exit_send_relay_plain(cc, PCOMM_RELAY_END, sid, NULL, 0);
+    }
+
+    if (cc->streams[idx].expect_resp) {
+        pcomm_msg_type_t rt; uint8_t reph[32]; uint8_t *rp=NULL; uint32_t rpl=0;
+        if (pcomm_recv_packet(fd, &rt, reph, &rp, &rpl) == 0) {
+            uint8_t *packed=NULL; uint32_t packed_len=0;
+            if (pcomm_pack_packet(rt, reph, rp, rpl, &packed, &packed_len) == 0) {
+                exit_send_relay_plain(cc, PCOMM_RELAY_DATA, sid, packed, (uint16_t)packed_len);
+                free(packed);
+            }
+            free(rp);
+        }
+    }
+    close(fd);
+
+    cc->streams[idx].used = 0;
+    free(cc->streams[idx].req);
+    cc->streams[idx].req = NULL;
+    cc->streams[idx].req_len = 0;
+    return exit_send_relay_plain(cc, PCOMM_RELAY_END, sid, NULL, 0);
+}
+
+static int cell_handle_exit_plain(cell_conn_t *cc, const uint8_t *plain, uint16_t plain_len) {
+    uint8_t rcmd; uint16_t sid; const uint8_t *body; uint16_t bl;
+    if (pcomm_relay_plain_unpack(plain, plain_len, &rcmd, &sid, &body, &bl) != 0) return -1;
+
+    if (rcmd == PCOMM_RELAY_EXTEND) {
+        // body: hostlen host port eph_pub
+        if (bl < 1 + 2 + 32) return -1;
+        size_t off = 0;
+        uint8_t hl = body[off++];
+        if (hl == 0 || hl > 63 || bl < 1 + hl + 2 + 32) return -1;
+        char host[64];
+        memcpy(host, body+off, hl); host[hl] = '\0';
+        off += hl;
+        uint16_t port = get_u16(body + off); off += 2;
+        const uint8_t *client_eph_pub = body + off;
+
+        int nfd = net_connect_tcp(host, port);
+        if (nfd < 0) {
+            // send failure as END
+            return exit_send_relay_plain(cc, PCOMM_RELAY_END, 0, NULL, 0);
+        }
+        // send CREATE to next hop using forwarded client eph pub
+        if (send_cell_link(nfd, PCOMM_CELL_CREATE, client_eph_pub, 32) != 0) { close(nfd); return -1; }
+        uint8_t ccmd; uint8_t *cpl=NULL; uint16_t cpll=0;
+        if (recv_cell_link(nfd, &ccmd, &cpl, &cpll) != 0 || ccmd != PCOMM_CELL_CREATED || cpll != 32) {
+            free(cpl);
+            close(nfd);
+            return -1;
+        }
+        // reply EXTENDED with relay eph pub
+        int rc = exit_send_relay_plain(cc, PCOMM_RELAY_EXTENDED, 0, cpl, 32);
+        free(cpl);
+
+        // become middle hop
+        cc->down_fd = nfd;
+        return rc;
+    }
+
+    if (rcmd == PCOMM_RELAY_BEGIN) {
+        // body: hostlen host port expect
+        if (bl < 1 + 2 + 1) return -1;
+        size_t off = 0;
+        uint8_t hl = body[off++];
+        if (hl == 0 || hl > 63 || bl < 1 + hl + 2 + 1) return -1;
+        char host[64];
+        memcpy(host, body+off, hl); host[hl] = '\0';
+        off += hl;
+        uint16_t port = get_u16(body + off); off += 2;
+        uint8_t expect = body[off++];
+
+        for (int i=0;i<32;i++) {
+            if (!cc->streams[i].used) {
+                cc->streams[i].used = 1;
+                cc->streams[i].id = sid;
+                cc->streams[i].expect_resp = (expect != 0);
+                snprintf(cc->streams[i].host, sizeof(cc->streams[i].host), "%s", host);
+                cc->streams[i].port = port;
+                cc->streams[i].req = NULL;
+                cc->streams[i].req_len = 0;
+                break;
+            }
+        }
+        return exit_send_relay_plain(cc, PCOMM_RELAY_CONNECTED, sid, NULL, 0);
+    }
+
+    if (rcmd == PCOMM_RELAY_DATA) {
+        // append request bytes
+        for (int i=0;i<32;i++) {
+            if (cc->streams[i].used && cc->streams[i].id == sid) {
+                uint8_t *nb = (uint8_t*)realloc(cc->streams[i].req, cc->streams[i].req_len + bl);
+                if (!nb) return -1;
+                cc->streams[i].req = nb;
+                memcpy(cc->streams[i].req + cc->streams[i].req_len, body, bl);
+                cc->streams[i].req_len += bl;
+                return 0;
+            }
+        }
+        return 0;
+    }
+
+    if (rcmd == PCOMM_RELAY_END) {
+        return exit_process_stream_done(cc, sid);
+    }
+
+    return 0;
+}
+
+static int cell_loop(relay_state_t *st, int fd, const uint8_t *first_cell, uint32_t first_cell_len) {
+    cell_conn_t cc;
+    memset(&cc, 0, sizeof(cc));
+    cc.up_fd = fd;
+    cc.down_fd = -1;
+
+    // handle first message as if received
+    uint8_t *buf = (uint8_t*)malloc(first_cell_len);
+    if (!buf) return -1;
+    memcpy(buf, first_cell, first_cell_len);
+
+    uint8_t *pending_payload = buf;
+    uint32_t pending_len = first_cell_len;
+
+    static const uint8_t basepoint[32] = {9};
+
+    while (1) {
+        uint8_t cmd=0, flags=0; uint32_t cid=0; const uint8_t *cpl=NULL; uint16_t cpll=0;
+        if (pcomm_cell_unpack(pending_payload, pending_len, &cid, &cmd, &flags, &cpl, &cpll) != 0 || cid != 1) {
+            free(pending_payload);
+            return -1;
+        }
+        (void)flags;
+
+        if (cmd == PCOMM_CELL_CREATE) {
+            if (cc.built || cpll != 32) { free(pending_payload); return -1; }
+            const uint8_t *client_eph_pub = cpl;
+            uint8_t eph_priv[32], eph_pub[32];
+            pcomm_random(eph_priv, 32);
+            if (pcomm_x25519_derive(eph_priv, basepoint, eph_pub) != 0) { free(pending_payload); return -1; }
+            uint8_t shared[32];
+            if (pcomm_x25519_derive(eph_priv, client_eph_pub, shared) != 0) { free(pending_payload); return -1; }
+            if (derive_hop_keys(shared, cc.k_fwd, cc.k_bwd) != 0) { free(pending_payload); return -1; }
+            cc.built = 1;
+            send_cell_link(cc.up_fd, PCOMM_CELL_CREATED, eph_pub, 32);
+        } else if (cmd == PCOMM_CELL_RELAY) {
+            if (!cc.built) { free(pending_payload); return -1; }
+            if (cc.down_fd >= 0) {
+                // middle hop: decrypt one layer forward and forward
+                uint8_t *dec=NULL; uint16_t decl=0;
+                if (pcomm_relay_unwrap_one_forward(cc.k_fwd, 1, cpl, cpll, &dec, &decl) != 0) { free(pending_payload); return -1; }
+                send_cell_link(cc.down_fd, PCOMM_CELL_RELAY, dec, decl);
+                free(dec);
+            } else {
+                // exit hop: decrypt and parse
+                uint8_t *plain=NULL; uint16_t plain_len=0;
+                if (pcomm_relay_unwrap_one_forward(cc.k_fwd, 1, cpl, cpll, &plain, &plain_len) == 0) {
+                    cell_handle_exit_plain(&cc, plain, plain_len);
+                    free(plain);
+                }
+            }
+        } else if (cmd == PCOMM_CELL_PADDING) {
+            // ignore
+        } else if (cmd == PCOMM_CELL_DESTROY) {
+            free(pending_payload);
+            break;
+        }
+
+        free(pending_payload);
+        pending_payload = NULL;
+        pending_len = 0;
+
+        // select for next message from upstream or downstream
+        fd_set rfds;
+        FD_ZERO(&rfds);
+        FD_SET(cc.up_fd, &rfds);
+        int maxfd = cc.up_fd;
+        if (cc.down_fd >= 0) {
+            FD_SET(cc.down_fd, &rfds);
+            if (cc.down_fd > maxfd) maxfd = cc.down_fd;
+        }
+        if (select(maxfd+1, &rfds, NULL, NULL, NULL) <= 0) continue;
+
+        if (cc.down_fd >= 0 && FD_ISSET(cc.down_fd, &rfds)) {
+            // read from downstream and wrap one backward layer, send upstream
+            uint8_t dcmd; uint8_t *dpl=NULL; uint16_t dpll=0;
+            if (recv_cell_link(cc.down_fd, &dcmd, &dpl, &dpll) != 0) { free(dpl); break; }
+            if (dcmd == PCOMM_CELL_RELAY) {
+                uint8_t *enc=NULL; uint16_t encl=0;
+                if (pcomm_relay_wrap_one_backward(cc.k_bwd, 1, dpl, dpll, &enc, &encl) == 0) {
+                    send_cell_link(cc.up_fd, PCOMM_CELL_RELAY, enc, encl);
+                    free(enc);
+                }
+            }
+            free(dpl);
+            continue;
+        }
+
+        if (FD_ISSET(cc.up_fd, &rfds)) {
+            // read next packet from upstream
+            pcomm_msg_type_t t; uint8_t eph[32]; uint8_t *p=NULL; uint32_t pl=0;
+            if (pcomm_recv_packet(cc.up_fd, &t, eph, &p, &pl) != 0) { free(p); break; }
+            if (t != PCOMM_MSG_CELL) { free(p); continue; }
+            pending_payload = p;
+            pending_len = pl;
+            continue;
+        }
+    }
+
+    if (cc.down_fd >= 0) close(cc.down_fd);
+    // free any stream buffers
+    for (int i=0;i<32;i++) free(cc.streams[i].req);
     return 0;
 }
 
@@ -214,6 +547,14 @@ static void *handle_conn(void *arg) {
     if (pcomm_recv_packet(fd, &type, eph_pub, &payload, &payload_len) != 0) {
         close(fd);
         free(payload);
+        return NULL;
+    }
+
+    if (type == PCOMM_MSG_CELL) {
+        // Long-lived circuit connection.
+        cell_loop(st, fd, payload, payload_len);
+        free(payload);
+        close(fd);
         return NULL;
     }
 
@@ -244,6 +585,7 @@ static void *handle_conn(void *arg) {
             if (outfd >= 0) {
                 if (pcomm_send_packet(outfd, PCOMM_MSG_ONION, eph_pub, next_payload, next_payload_len) == 0) {
                     if (inst == PCOMM_INST_FORWARD_RR) {
+                        // read exactly one response packet and send it back
                         pcomm_msg_type_t rtype;
                         uint8_t reph[32];
                         uint8_t *rp = NULL; uint32_t rpl = 0;
@@ -275,6 +617,7 @@ static void *handle_conn(void *arg) {
             free(deliver_payload);
         }
     } else if (type == PCOMM_MSG_DELIVER) {
+        // payload = sealed box to us
         uint8_t *plain = NULL;
         size_t plain_len = 0;
         if (pcomm_open_seal(st->id.privkey, payload, payload_len, &plain, &plain_len) == 0) {

--- a/src/relay.h
+++ b/src/relay.h
@@ -4,6 +4,7 @@
 #include "pcomm.h"
 #include "db.h"
 
+// Starts relay server in a background thread.
 int pcomm_relay_start(const pcomm_config_t *cfg, const pcomm_identity_t *id, pcomm_db_t *db);
 
 #endif

--- a/src/sb.c
+++ b/src/sb.c
@@ -47,6 +47,7 @@ int sb_appendf(sb_t *sb, const char *fmt, ...) {
     va_end(ap);
     if (n < 0) return -1;
     if ((size_t)n >= sizeof(tmp)) {
+        // big format: allocate exact
         char *big = (char*)malloc((size_t)n + 1);
         if (!big) return -1;
         va_start(ap, fmt);


### PR DESCRIPTION
Long-lived 3-hop circuits (Tor-like) using CELL_CREATE/CELL_RELAY and per-hop forward/backward keys

Stream multiplexing inside a circuit (RELAY_BEGIN / RELAY_DATA / RELAY_END) so the client can reuse the same circuit for many requests/messages without rebuilding paths

A real BEP-5 style DHT (UDP/KRPC + bencode) used for descriptor + mailbox host discovery:

storage relays that receive DESC_PUT / MB_PUT automatically announce themselves in the DHT under the user’s descriptor/mailbox infohash

senders/recipients query the DHT via get_peers to find where to DESC_GET / MB_GET

keeps HSDir deterministic fallback if the DHT has no results yet

Kept deps minimal: OpenSSL + SQLite + pthread (bencode + DHT are internal)